### PR TITLE
fix(custom-export): cascade publishedOnly filter into variants

### DIFF
--- a/docs/api/custom-exports.md
+++ b/docs/api/custom-exports.md
@@ -77,7 +77,10 @@ interface ExportFilters {
   aiCategory: string;               // "all" or ObjectId string
   showNew: boolean;                 // Default: false
   showRecommended: boolean;         // Default: false
-  publishedOnly: boolean;           // Default: false
+  publishedOnly: boolean;           // Default: false. Cascades into variants:
+                                    // excludes unpublished parents AND strips
+                                    // unpublished variants from child_products
+                                    // before all other filters and row generation.
 }
 ```
 
@@ -294,6 +297,11 @@ product matches IF:
   AND (showNew is false OR product.new is true)
   AND (showRecommended is false OR product.recomended is true)
   AND (publishedOnly is false OR product.published is true)
+
+If publishedOnly is true, the filter also narrows each surviving parent's
+child_products to only those variants whose own `published` field is true —
+all downstream filters (stock, price, image, search) and row generation
+operate on this narrowed set, so unpublished variants never appear in output.
 ```
 
 ---

--- a/src/services/customExport.service.js
+++ b/src/services/customExport.service.js
@@ -621,7 +621,17 @@ const getPriceFromPriority = (variant, pricelistPriority) => {
  * @returns {Array} Filtered products
  */
 const applyFilters = (products, filters, pricelistPriority = []) => {
-    return products.filter(product => {
+    // publishedOnly cascades into variants: drop unpublished parents entirely,
+    // and narrow each surviving parent's child_products to the published ones.
+    // All downstream filters (stock, price, image, search) and row generation
+    // then operate on the narrowed set, so unpublished variants never appear.
+    const input = filters.publishedOnly
+        ? products
+            .filter(p => p.published)
+            .map(p => ({ ...p, child_products: (p.child_products || []).filter(v => v.published) }))
+        : products;
+
+    return input.filter(product => {
         // Search filter
         if (filters.search && filters.search.trim() !== '') {
             const searchLower = filters.search.toLowerCase();
@@ -700,7 +710,6 @@ const applyFilters = (products, filters, pricelistPriority = []) => {
         // Boolean flags
         if (filters.showNew && !product.new) return false;
         if (filters.showRecommended && !product.recomended) return false;
-        if (filters.publishedOnly && !product.published) return false;
         if (filters.excludeCloseOut && product.product_name?.toUpperCase().includes('CLOSE OUT')) return false;
         if (filters.excludeCloseOut && product.images?.some(img => img?.toLowerCase().includes('close-out'))) return false;
 


### PR DESCRIPTION
## Summary
- Drop unpublished parents and strip unpublished variants from `child_products` before downstream filters run, so unpublished variants never leak into exports.
- Update `docs/api/custom-exports.md` to document the cascading behavior of `publishedOnly`.

## Test plan
- [ ] Run a custom export with `publishedOnly: true` against a product whose parent is published but has a mix of published/unpublished variants — confirm only published variants appear in CSV/JSON/XML output.
- [ ] Run a custom export with `publishedOnly: true` against an unpublished parent — confirm the product is excluded entirely.
- [ ] Run a custom export with `publishedOnly: false` — confirm behavior is unchanged (all parents and variants pass through).
- [ ] Verify stock/price/image/search filters still operate correctly on the narrowed variant set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)