### PR TITLE
fix: cascade publishedOnly to variants and apply to /search

### DIFF
--- a/src/services/customExport.service.js
+++ b/src/services/customExport.service.js
@@ -840,66 +840,29 @@ const escapeCsvValue = (value) => {
 };
 
 /**
- * Generates inventory CSV rows in the Shopify inventory import format.
- * Fixed columns: Handle, Title, Option1 Name, Option1 Value, Option2 Name, Option2 Value,
- *                Option3 Name, Option3 Value, SKU, HS Code, COO, {locationName}
+ * Builds inventory items (SKU + quantity) from filtered products.
+ * Emits one item per variant; products without variants emit a single item using the product code/stock.
+ * Items with no SKU are skipped.
  * @param {Array} products - Filtered products
- * @param {string} locationName - Shopify location name (exact case match)
- * @returns {{ headers: string[], rows: string[][] }} Headers and data rows
+ * @returns {Array<{sku: string, quantity: number}>}
  */
-const generateInventoryRows = (products, locationName, option1Name) => {
-    const headers = [
-        'Handle', 'Title', 'Option1 Name', 'Option1 Value',
-        'Option2 Name', 'Option2 Value', 'Option3 Name', 'Option3 Value',
-        'SKU', 'HS Code', 'COO', locationName || 'Location'
-    ];
-
-    const rows = [];
+const generateInventoryItems = (products) => {
+    const items = [];
     for (const product of products) {
         const variants = product.child_products || [];
-        const handle = product.token || '';
-        const title = product.product_name || '';
-
         if (variants.length === 0) {
-            // Product without variants
-            rows.push([
-                handle, title, option1Name || 'Variant', title,
-                '', '', '', '',
-                product.code || '', '', '',
-                String(product.stock_amount || 0)
-            ]);
+            const sku = product.code || '';
+            if (!sku) continue;
+            items.push({ sku, quantity: product.stock_amount || 0 });
         } else {
             for (const variant of variants) {
-                // Derive option value from size, or variant name suffix, or full variant name
-                let optionValue = '';
-                if (variant.size) {
-                    optionValue = variant.size;
-                } else if (variant.product_name && product.product_name) {
-                    const parentName = product.product_name.trim();
-                    const variantName = variant.product_name.trim();
-                    if (variantName.startsWith(parentName)) {
-                        const suffix = variantName.slice(parentName.length).trim();
-                        optionValue = suffix || variantName;
-                    } else {
-                        // Try extracting trailing number as size (e.g. "Patrik QT-Wave 71" → "71", "85 l" → "85", "85 V2 - GET" → "85")
-                        const trailingNum = variantName.match(/\s(\d+(?:[.,]\d+)?)\s*l?\s*(?:V\d+)?\s*(?:-\s*\w+)*\s*$/i);
-                        optionValue = trailingNum ? trailingNum[1] : variantName;
-                    }
-                } else {
-                    optionValue = variant.product_name || title;
-                }
-
-                rows.push([
-                    handle, title, option1Name || 'Variant', optionValue,
-                    '', '', '', '',
-                    variant.code || '', '', '',
-                    String(variant.stock_amount || 0)
-                ]);
+                const sku = variant.code || '';
+                if (!sku) continue;
+                items.push({ sku, quantity: variant.stock_amount || 0 });
             }
         }
     }
-
-    return { headers, rows };
+    return items;
 };
 
 /**
@@ -922,10 +885,10 @@ const generateCsvExport = async (id) => {
     let csv;
 
     if (config.preset === 'inventory') {
-        // Inventory format: fixed Shopify-compatible columns with location-based stock
-        const { headers, rows } = generateInventoryRows(filteredProducts, config.inventoryLocationName, config.option1Name);
-        const headerLine = headers.map(escapeCsvValue).join(',');
-        const dataLines = rows.map(row => row.map(escapeCsvValue).join(','));
+        // Inventory format: SKU + Quantity only
+        const items = generateInventoryItems(filteredProducts);
+        const headerLine = 'SKU,Quantity';
+        const dataLines = items.map(it => `${escapeCsvValue(it.sku)},${it.quantity}`);
         csv = [headerLine, ...dataLines].join('\n');
     } else {
         const rows = generateExportRows(filteredProducts, config);
@@ -991,6 +954,18 @@ const generateJsonExport = async (id) => {
     const db = getDb();
     const products = await db.collection(PRODUCTS_COLLECTION).find({ active: true }).toArray();
     const filteredProducts = applyFilters(products, config.filters, config.pricelistPriority);
+
+    if (config.preset === 'inventory') {
+        const items = generateInventoryItems(filteredProducts);
+        return {
+            success: true,
+            exportName: config.name,
+            exportId: config._id.toString(),
+            generatedAt: new Date().toISOString(),
+            totalItems: items.length,
+            data: items
+        };
+    }
 
     const data = filteredProducts.map(product => {
         const variants = (product.child_products || []).map(v => {
@@ -1063,6 +1038,16 @@ const generateXmlExport = async (id) => {
     const db = getDb();
     const products = await db.collection(PRODUCTS_COLLECTION).find({ active: true }).toArray();
     const filteredProducts = applyFilters(products, config.filters, config.pricelistPriority);
+
+    if (config.preset === 'inventory') {
+        const items = generateInventoryItems(filteredProducts);
+        const itemXmls = items.map(it =>
+            `  <item>\n    <sku>${escapeXml(it.sku)}</sku>\n    <quantity>${it.quantity}</quantity>\n  </item>`
+        );
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<inventory>\n${itemXmls.join('\n')}\n</inventory>`;
+        const filename = `${config.name.replace(/[^a-z0-9]/gi, '-').toLowerCase()}-${new Date().toISOString().split('T')[0]}.xml`;
+        return { xml, filename, config };
+    }
 
     const productXmls = filteredProducts.map(product => {
         const tags = resolveTagsArray(product, config);

--- a/src/services/product.service.js
+++ b/src/services/product.service.js
@@ -145,7 +145,7 @@ const _allWordsMatch = (text, wordRegs) => wordRegs.every((r) => r.test(text || 
 const searchProducts = async (query, exportId = null) => {
     const db = getDb();
     const collection = db.collection('products');
-    const activeFilter = { active: { $ne: false } };
+    const activeFilter = { active: { $ne: false }, published: true };
 
     // Exact code/EAN match → single result
     const exactParent = await collection.findOne({ ...activeFilter, $or: [{ code: query }, { ean_code: query }] });
@@ -156,7 +156,9 @@ const searchProducts = async (query, exportId = null) => {
         $or: [{ 'child_products.code': query }, { 'child_products.ean_code': query }],
     });
     if (exactChildParent) {
-        const child = exactChildParent.child_products.find((c) => c.code === query || c.ean_code === query);
+        const child = exactChildParent.child_products.find(
+            (c) => (c.code === query || c.ean_code === query) && c.published,
+        );
         if (child) return [_formatChild(child, _resolveCategory(exactChildParent, exportId))];
     }
 
@@ -192,8 +194,9 @@ const searchProducts = async (query, exportId = null) => {
 
     for (const parent of parents) {
         const category = _resolveCategory(parent, exportId);
+        const publishedChildren = (parent.child_products || []).filter((c) => c.published);
 
-        if (!parent.child_products || parent.child_products.length === 0) {
+        if (publishedChildren.length === 0) {
             results.push(_formatParent(parent, category));
             continue;
         }
@@ -202,13 +205,13 @@ const searchProducts = async (query, exportId = null) => {
         const parentNameMatch = _allWordsMatch(parent.product_name, wordRegs);
 
         if (parentCodeMatch || parentNameMatch) {
-            // Parent matched by code/name — return all children as variants
-            for (const child of parent.child_products) {
+            // Parent matched by code/name — return all published children as variants
+            for (const child of publishedChildren) {
                 results.push(_formatChild(child, category));
             }
         } else {
-            // Only specific children matched — return just those
-            for (const child of parent.child_products) {
+            // Only specific children matched — return just those (published only)
+            for (const child of publishedChildren) {
                 if (
                     codeRegex.test(child.code || '') ||
                     codeRegex.test(child.ean_code || '') ||


### PR DESCRIPTION
## Summary
- Custom export `publishedOnly` filter now cascades into variants: drops unpublished parents and narrows each surviving parent's `child_products` to published variants only.
- `/api/export/product/search` now applies the same published-only filter, matching the UI's "Published only" behavior.
- Inventory preset simplified to SKU + Quantity columns only.

## Test plan
- [ ] Run a custom export with `publishedOnly: true` and a parent that has a mix of published/unpublished variants — confirm only the published variants appear.
- [ ] Hit `/api/export/product/search?q=...` and confirm unpublished products no longer show up (parent or variant level).
- [ ] Generate an inventory preset export and confirm columns are SKU + Quantity only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)