### PR TITLE
fix: correct .gitignore for products.csv / .claude split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env* 
 node_modules/
-products.csv.claude/settings.local.json
+products.csv
+.claude/settings.local.json


### PR DESCRIPTION
PR #18 appended `.claude/settings.local.json` onto the `products.csv` line (the file had no trailing newline), creating the pattern `products.csv.claude/settings.local.json` which ignores nothing. This splits them onto separate lines so both `products.csv` and `.claude/settings.local.json` are ignored again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)