### PR TITLE
Fix docker image name in build-and-push.sh

### DIFF
--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-IMAGE="etiamsi/t4a-export-api"
+IMAGE="time4action/t4a-partner-portal-api"
 
 docker build . -t "$IMAGE"
 docker push "$IMAGE"


### PR DESCRIPTION
`build-and-push.sh` used the stale image name `etiamsi/t4a-export-api`. Corrects it to `time4action/t4a-partner-portal-api`, matching `build.cmd`/`push.cmd` and the deployment `docker-compose.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)