### PR TITLE
fix: do not override authSource in MongoClient

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const { ensureIndexesAndMigrate } = require('./src/services/customExport.service
 const PORT = process.env.PORT || 3000;
 
 const startServer = async () => {
+
   await connectToDb();
   await ensureIndexesAndMigrate();
 

--- a/src/services/db/mongo.service.js
+++ b/src/services/db/mongo.service.js
@@ -19,9 +19,9 @@ if (!mongoUri || !dbName) {
     throw new Error('MONGO_URI and MONGO_DB_NAME must be set in environment variables.');
 }
 
-// The `authSource` option tells the driver which database to use for authentication.
-// This is necessary if the user's credentials are not stored in the 'admin' database.
-const client = new MongoClient(mongoUri, { authSource: dbName });
+// authSource comes from MONGO_URI (e.g. `?authSource=admin`). Do not override it
+// here with dbName — that points auth at the wrong database and breaks login.
+const client = new MongoClient(mongoUri);
 /**
  * @type {MongoDb}
  */


### PR DESCRIPTION
## Summary
- `authSource` now comes from `MONGO_URI` (e.g. `?authSource=admin`)
- Stop passing `dbName` as `authSource` to `MongoClient` — it pointed authentication at the wrong database and broke login
- Minor whitespace in `index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)