### PR TITLE
Shopify/Own Sources GA, admin partners API, PNV scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,13 @@ All routes are under `/api/export`:
 | `/api/export/recharge` | `src/routes/rechargeRoutes.js` |
 | `/api/export/webhooks` | `src/routes/webhookRoutes.js` — n8n triggers |
 
+Internal admin surface (bearer-gated by `internalAdminToken` / `PARTNER_ADMIN_TOKEN`, consumed by the t4a-admin Partners section — NOT under `/api/export`):
+
+| Prefix | File |
+|---|---|
+| `/api/admin/partners` | `src/routes/adminPartnersRoutes.js` — per-partner insight |
+| `/api/admin/system` | `src/routes/adminSystemRoutes.js` — scheduler status + manual triggers (`GET /sync`, `POST /sync/pnv/run` full pipeline, `POST /sync/own-sources/:feedId/run`). Backed by `pnvScheduler.getStatus()` / `runManualRefresh()`. |
+
 ### Authentication
 
 Two middleware options are available:
@@ -51,7 +58,7 @@ Triggered by `POST /api/export/webhooks/sync/pnv`. Responds `202` immediately an
 
 1. `pnvProductsSync.service.js` — authenticates with PNV (SHA1-hashed password in cookie), triggers CSV export, downloads CSV to `DATA_PATH/pnv/products.csv`
 2. `processPnvProductExport.service.js` — parses the CSV, maps fields via `src/config/pnv/products.js`
-3. Enriches each product with warehouse stock and pricing from Metakocka (`src/services/metakocka/`)
+3. Enriches each product with warehouse stock and pricing from Metakocka (`src/services/metakocka/`). Stock stored as `stock_amount` is the **free** (available-to-sell) amount = `free_amount`, falling back to `amount - reserved_amount` when a company has no reservations. Rows are **summed per code** across a warehouse's microlocations (`warehouse.service.js`); never use raw `amount` (it includes reservations → overselling).
 4. Upserts products into the `products` MongoDB collection; products absent from CSV are soft-deleted (`active: false`)
 5. Optionally POSTs a callback to a `webhook` URL when done
 
@@ -77,6 +84,8 @@ The **inventory preset** uses a dedicated code path (`generateInventoryRows()`) 
 | `exports` | Export definitions (name, AI categorization enabled, roles/users) |
 | `export_configs` | Custom export configurations (fields, filters, presets) |
 | `analytics` | Function performance and API request logs |
+| `scheduler_state` | Per-scheduler state (`pnv-products-sync` last-run + lock; `shopify-pending-cleanup` last-sweep) |
+| `pnv_sync_runs` | PNV catalogue-refresh run history (one doc per run; `trigger`, `result`, `stats`, durations) |
 
 ### `products` document shape
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const startServer = async () => {
   await ensureShopifyIndexes();
   await ensureExternalIndexes();
   await ensureActivityIndexes();
+  await pnvScheduler.ensureIndexes();
 
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { connectToDb } = require('./src/services/db/mongo.service');
 const { ensureIndexesAndMigrate } = require('./src/services/customExport.service');
 const { ensureIndexes: ensureShopifyIndexes } = require('./src/services/shopify/shopifyConnection.service');
 const { ensureIndexes: ensureExternalIndexes } = require('./src/services/external/ownSource.service');
+const { ensureIndexes: ensureActivityIndexes } = require('./src/services/activity.service');
 const externalScheduler = require('./src/services/external/externalScheduler.service');
 const pnvScheduler = require('./src/services/pnv/pnvScheduler.service');
 const shopifyPendingCleanup = require('./src/services/shopify/pendingCleanup.service');
@@ -30,6 +31,7 @@ const startServer = async () => {
   await ensureIndexesAndMigrate();
   await ensureShopifyIndexes();
   await ensureExternalIndexes();
+  await ensureActivityIndexes();
 
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);

--- a/src/app.js
+++ b/src/app.js
@@ -20,8 +20,14 @@ app.use(express.static(path.join(__dirname, '..', 'public')));
 
 const healthRoutes = require('./routes/healthRoutes');
 const productRoutes = require('./routes/productRoutes');
+const internalAdminToken = require('./middleware/internalAdminToken');
+const adminPartnersRoutes = require('./routes/adminPartnersRoutes');
 app.use('/api/export/health', healthRoutes);
 app.use('/api/product', productRoutes);
 app.use('/api/export', exportRoutes);
+
+// Internal admin surface consumed by the t4a-admin "Partners" section. Bearer-token
+// gated (PARTNER_ADMIN_TOKEN); not part of the partner-facing /api/export tree.
+app.use('/api/admin/partners', internalAdminToken, adminPartnersRoutes);
 
 module.exports = { app };

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,7 @@ const healthRoutes = require('./routes/healthRoutes');
 const productRoutes = require('./routes/productRoutes');
 const internalAdminToken = require('./middleware/internalAdminToken');
 const adminPartnersRoutes = require('./routes/adminPartnersRoutes');
+const adminSystemRoutes = require('./routes/adminSystemRoutes');
 app.use('/api/export/health', healthRoutes);
 app.use('/api/product', productRoutes);
 app.use('/api/export', exportRoutes);
@@ -29,5 +30,8 @@ app.use('/api/export', exportRoutes);
 // Internal admin surface consumed by the t4a-admin "Partners" section. Bearer-token
 // gated (PARTNER_ADMIN_TOKEN); not part of the partner-facing /api/export tree.
 app.use('/api/admin/partners', internalAdminToken, adminPartnersRoutes);
+
+// Scheduler status + manual triggers for the t4a-admin "Catalogue Sync" page. Same bearer gate.
+app.use('/api/admin/system', internalAdminToken, adminSystemRoutes);
 
 module.exports = { app };

--- a/src/controllers/adminPartnersController.js
+++ b/src/controllers/adminPartnersController.js
@@ -1,0 +1,301 @@
+const { ObjectId } = require('mongodb');
+const { getDb } = require('../services/db/mongo.service');
+
+/**
+ * Read-only insight surface for the t4a-admin "Partners" section. Every endpoint
+ * is gated by internalAdminToken (shared bearer) and aggregates the partner
+ * portal's own collections, keyed by Auth0 `sub` (the partner identity). Secrets
+ * (Shopify tokens, feed auth tokens) are never included in any response.
+ */
+
+const DOWNLOADS_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Drops encrypted tokens / claim hashes from a connection doc. */
+function publicConnection(c) {
+    if (!c) return c;
+    const { accessTokenEnc, refreshTokenEnc, claimTokenHash, ...rest } = c;
+    return { ...rest, _id: c._id?.toString?.() ?? c._id };
+}
+
+/** Drops the feed auth token from an own_source doc. */
+function publicFeed(f) {
+    if (!f) return f;
+    const feed = f.feed ? { url: f.feed.url, authHeaderName: f.feed.authHeaderName || null } : null;
+    return { ...f, _id: f._id?.toString?.() ?? f._id, feed };
+}
+
+/**
+ * GET /api/admin/partners/overview[?subs=a,b,c]
+ * Per-partner activity rollup. Returns an array keyed by ownerSub; the admin
+ * app left-joins it onto the Auth0 export-role user list.
+ */
+exports.overview = async (req, res) => {
+    try {
+        const db = getDb();
+        const subsFilter = (req.query.subs || '')
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        const match = subsFilter.length ? { ownerSub: { $in: subsFilter } } : {};
+        const ownerMatch = subsFilter.length ? { 'owner.sub': { $in: subsFilter } } : {};
+        const since = new Date(Date.now() - DOWNLOADS_WINDOW_MS);
+
+        const [connAgg, feedAgg, exportAgg, downloadAgg, rollups, topEventsAgg] = await Promise.all([
+            db.collection('shopify_connections').aggregate([
+                { $match: { ...match, status: { $ne: 'uninstalled' } } },
+                { $sort: { lastSyncAt: -1 } },
+                { $group: {
+                    _id: '$ownerSub',
+                    total: { $sum: 1 },
+                    active: { $sum: { $cond: [{ $eq: ['$status', 'active'] }, 1, 0] } },
+                    lastSyncAt: { $max: '$lastSyncAt' },
+                    lastSyncStatus: { $first: '$lastSyncStatus' },
+                    email: { $first: '$ownerEmail' }
+                } }
+            ]).toArray(),
+            db.collection('own_sources').aggregate([
+                { $match: match },
+                { $sort: { 'health.lastImportAt': -1 } },
+                { $group: {
+                    _id: '$ownerSub',
+                    total: { $sum: 1 },
+                    active: { $sum: { $cond: [{ $eq: ['$status', 'active'] }, 1, 0] } },
+                    lastImportAt: { $max: '$health.lastImportAt' },
+                    lastResult: { $first: '$health.lastResult' },
+                    email: { $first: '$ownerEmail' }
+                } }
+            ]).toArray(),
+            db.collection('export_configs').aggregate([
+                { $match: ownerMatch },
+                { $group: { _id: '$owner.sub', configs: { $sum: 1 }, email: { $first: '$owner.email' } } }
+            ]).toArray(),
+            db.collection('activity_log').aggregate([
+                { $match: { ...match, eventType: 'export_download', timestamp: { $gte: since } } },
+                { $group: { _id: '$ownerSub', downloads30d: { $sum: 1 } } }
+            ]).toArray(),
+            db.collection('partner_activity').find(match).toArray(),
+            db.collection('activity_log').aggregate([
+                { $match: match },
+                { $group: { _id: { ownerSub: '$ownerSub', eventType: '$eventType' }, count: { $sum: 1 } } },
+                { $sort: { count: -1 } }
+            ]).toArray()
+        ]);
+
+        const map = new Map();
+        const ensure = (sub, email) => {
+            if (!sub) return null;
+            if (!map.has(sub)) {
+                map.set(sub, {
+                    ownerSub: sub,
+                    email: email || null,
+                    shopifyConnections: { total: 0, active: 0, lastSyncAt: null, lastSyncStatus: null },
+                    exports: { configs: 0, downloads30d: 0 },
+                    feeds: { total: 0, active: 0, lastImportAt: null, lastResult: null },
+                    lastActiveAt: null,
+                    loginCount: 0,
+                    topEvents: []
+                });
+            }
+            const row = map.get(sub);
+            if (email && !row.email) row.email = email;
+            return row;
+        };
+
+        for (const c of connAgg) {
+            const row = ensure(c._id, c.email);
+            if (row) row.shopifyConnections = { total: c.total, active: c.active, lastSyncAt: c.lastSyncAt || null, lastSyncStatus: c.lastSyncStatus || null };
+        }
+        for (const f of feedAgg) {
+            const row = ensure(f._id, f.email);
+            if (row) row.feeds = { total: f.total, active: f.active, lastImportAt: f.lastImportAt || null, lastResult: f.lastResult || null };
+        }
+        for (const e of exportAgg) {
+            const row = ensure(e._id, e.email);
+            if (row) row.exports.configs = e.configs;
+        }
+        for (const d of downloadAgg) {
+            const row = ensure(d._id);
+            if (row) row.exports.downloads30d = d.downloads30d;
+        }
+        for (const r of rollups) {
+            const row = ensure(r.ownerSub, r.email);
+            if (row) { row.lastActiveAt = r.lastActiveAt || null; row.loginCount = r.loginCount || 0; }
+        }
+        for (const t of topEventsAgg) {
+            const row = ensure(t._id.ownerSub);
+            if (row && row.topEvents.length < 5) row.topEvents.push({ eventType: t._id.eventType, count: t.count });
+        }
+
+        res.json({ success: true, partners: Array.from(map.values()) });
+    } catch (error) {
+        console.error('[admin/partners] overview error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * GET /api/admin/partners/:sub
+ * Full detail for one partner: connections, recent sync jobs, feeds, export
+ * configs, recent downloads, and a "most interacted with" breakdown.
+ */
+exports.detail = async (req, res) => {
+    try {
+        const db = getDb();
+        const sub = req.params.sub;
+        const since = new Date(Date.now() - DOWNLOADS_WINDOW_MS);
+
+        const connections = (await db.collection('shopify_connections')
+            .find({ ownerSub: sub, status: { $ne: 'uninstalled' } })
+            .sort({ installedAt: 1 })
+            .toArray()).map(publicConnection);
+
+        const connIds = connections.map((c) => new ObjectId(c._id));
+        const syncJobs = connIds.length
+            ? await db.collection('shopify_sync_jobs')
+                .find({ connectionId: { $in: connIds } })
+                .sort({ startedAt: -1 })
+                .limit(20)
+                .toArray()
+            : [];
+
+        const feeds = (await db.collection('own_sources')
+            .find({ ownerSub: sub })
+            .sort({ createdAt: 1 })
+            .toArray()).map(publicFeed);
+
+        const exportConfigs = await db.collection('export_configs')
+            .find({ $or: [{ 'owner.sub': sub }, { 'accessList.sub': sub }] })
+            .project({ name: 1, description: 1, isActive: 1, preset: 1, createdAt: 1, updatedAt: 1, 'owner.sub': 1 })
+            .toArray();
+
+        const recentDownloads = await db.collection('activity_log')
+            .find({ ownerSub: sub, eventType: 'export_download' })
+            .sort({ timestamp: -1 })
+            .limit(20)
+            .toArray();
+
+        const [eventBreakdown, topExports, rollup] = await Promise.all([
+            db.collection('activity_log').aggregate([
+                { $match: { ownerSub: sub } },
+                { $group: { _id: '$eventType', count: { $sum: 1 } } },
+                { $sort: { count: -1 } }
+            ]).toArray(),
+            db.collection('activity_log').aggregate([
+                { $match: { ownerSub: sub, eventType: 'export_download', timestamp: { $gte: since } } },
+                { $group: { _id: '$resourceId', count: { $sum: 1 } } },
+                { $sort: { count: -1 } },
+                { $limit: 5 }
+            ]).toArray(),
+            db.collection('partner_activity').findOne({ ownerSub: sub })
+        ]);
+
+        // Resolve export-config names for the top-exports breakdown.
+        const cfgById = new Map(exportConfigs.map((c) => [c._id.toString(), c.name]));
+
+        res.json({
+            success: true,
+            partner: {
+                ownerSub: sub,
+                email: rollup?.email || connections[0]?.ownerEmail || null,
+                lastActiveAt: rollup?.lastActiveAt || null,
+                loginCount: rollup?.loginCount || 0,
+                connections,
+                syncJobs,
+                feeds,
+                exportConfigs,
+                recentDownloads,
+                mostInteractedWith: {
+                    events: eventBreakdown.map((e) => ({ eventType: e._id, count: e.count })),
+                    topExports: topExports.map((t) => ({
+                        exportConfigId: t._id,
+                        name: cfgById.get(String(t._id)) || null,
+                        downloads: t.count
+                    }))
+                }
+            }
+        });
+    } catch (error) {
+        console.error('[admin/partners] detail error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/** GET /api/admin/partners/:sub/activity?limit=100 — reverse-chron event stream. */
+exports.activity = async (req, res) => {
+    try {
+        const db = getDb();
+        const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 100, 1), 500);
+        const events = await db.collection('activity_log')
+            .find({ ownerSub: req.params.sub })
+            .sort({ timestamp: -1 })
+            .limit(limit)
+            .toArray();
+        res.json({ success: true, events });
+    } catch (error) {
+        console.error('[admin/partners] activity error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/** GET /api/admin/partners/:sub/notes — newest first. */
+exports.listNotes = async (req, res) => {
+    try {
+        const db = getDb();
+        const notes = await db.collection('partner_notes')
+            .find({ ownerSub: req.params.sub })
+            .sort({ createdAt: -1 })
+            .toArray();
+        res.json({ success: true, notes });
+    } catch (error) {
+        console.error('[admin/partners] listNotes error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * POST /api/admin/partners/:sub/notes
+ * Body: { text, authorName, authorEmail }. Author identity is stamped by the
+ * admin app from its Auth0 session and trusted via the shared token.
+ */
+exports.addNote = async (req, res) => {
+    try {
+        const { text, authorName, authorEmail } = req.body || {};
+        if (!text || !String(text).trim()) {
+            return res.status(400).json({ success: false, error: 'text is required' });
+        }
+        const db = getDb();
+        const doc = {
+            ownerSub: req.params.sub,
+            text: String(text).trim(),
+            authorName: authorName || 'Admin',
+            authorEmail: authorEmail || null,
+            createdAt: new Date()
+        };
+        const result = await db.collection('partner_notes').insertOne(doc);
+        res.status(201).json({ success: true, note: { ...doc, _id: result.insertedId.toString() } });
+    } catch (error) {
+        console.error('[admin/partners] addNote error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/** DELETE /api/admin/partners/:sub/notes/:noteId */
+exports.deleteNote = async (req, res) => {
+    try {
+        if (!ObjectId.isValid(req.params.noteId)) {
+            return res.status(400).json({ success: false, error: 'invalid note id' });
+        }
+        const db = getDb();
+        const result = await db.collection('partner_notes').deleteOne({
+            _id: new ObjectId(req.params.noteId),
+            ownerSub: req.params.sub
+        });
+        if (result.deletedCount === 0) {
+            return res.status(404).json({ success: false, error: 'note not found' });
+        }
+        res.json({ success: true });
+    } catch (error) {
+        console.error('[admin/partners] deleteNote error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};

--- a/src/controllers/adminSystemController.js
+++ b/src/controllers/adminSystemController.js
@@ -1,0 +1,114 @@
+const { getDb } = require('../services/db/mongo.service');
+const pnvScheduler = require('../services/pnv/pnvScheduler.service');
+const pendingCleanup = require('../services/shopify/pendingCleanup.service');
+const externalImport = require('../services/external/externalImport.service');
+
+/**
+ * Read/trigger surface for the t4a-admin "Catalogue Sync" page. Gated by internalAdminToken
+ * (shared bearer), it exposes the in-app schedulers' status + history and lets an admin trigger
+ * a run on demand — without the admin app ever touching MongoDB directly. No secrets are returned.
+ */
+
+/** Own Sources scheduler enabled? Mirrors externalScheduler.service.js's EXTERNAL_SCHEDULER gate. */
+function ownSourcesEnabled() {
+    return (process.env.EXTERNAL_SCHEDULER || '').trim().toLowerCase() !== 'off';
+}
+
+/**
+ * GET /api/admin/system/sync
+ * Unified status for all three in-app schedulers: the PNV catalogue refresh, the Own Sources feed
+ * imports, and the Shopify pending-cleanup sweep.
+ */
+exports.syncStatus = async (req, res) => {
+    try {
+        const db = getDb();
+
+        // ── PNV catalogue refresh (state doc + computed isRunning + run history) ──
+        const pnv = await pnvScheduler.getStatus();
+
+        // ── Own Sources: per-feed health summary + recent run history across all feeds ──
+        const feedDocs = await db.collection('own_sources')
+            .find({})
+            .project({
+                feedId: 1, brand: 1, ownerSub: 1, ownerEmail: 1, status: 1,
+                'schedule.enabled': 1, 'schedule.frequency': 1, nextRunAt: 1,
+                lockedUntil: 1, runningBy: 1, health: 1
+            })
+            .sort({ 'health.lastImportAt': -1 })
+            .toArray();
+        const now = Date.now();
+        const feeds = feedDocs.map((f) => ({
+            feedId: f.feedId,
+            brand: f.brand || f.feedId,
+            ownerEmail: f.ownerEmail || null,
+            status: f.status || null,
+            scheduleEnabled: !!f.schedule?.enabled,
+            frequency: f.schedule?.frequency || null,
+            nextRunAt: f.nextRunAt || null,
+            isRunning: !!(f.runningBy && f.lockedUntil && new Date(f.lockedUntil).getTime() > now),
+            health: {
+                lastImportAt: f.health?.lastImportAt || null,
+                lastResult: f.health?.lastResult || null,
+                lastError: f.health?.lastError || null,
+                counts: f.health?.counts || null
+            }
+        }));
+        const ownSourceRuns = await db.collection('external_import_runs')
+            .find({}).sort({ finishedAt: -1 }).limit(20).toArray();
+
+        // ── Shopify pending-cleanup (best-effort sweep; minimal last-sweep state) ──
+        const sweepState = await db.collection('scheduler_state').findOne({ _id: pendingCleanup.STATE_ID });
+        const shopifyCleanup = {
+            intervalMs: pendingCleanup.SWEEP_INTERVAL_MS,
+            pendingTtlMs: pendingCleanup.PENDING_TTL_MS,
+            lastSweepAt: sweepState?.lastSweepAt || null,
+            lastRemoved: sweepState?.lastRemoved ?? null
+        };
+
+        res.json({
+            success: true,
+            pnv,
+            ownSources: { enabled: ownSourcesEnabled(), feeds, runs: ownSourceRuns },
+            shopifyCleanup
+        });
+    } catch (error) {
+        console.error('[admin/system] syncStatus error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * POST /api/admin/system/sync/pnv/run
+ * Triggers the full catalogue pipeline (PNV → AI → Shopify) on demand, identical to the cron.
+ * 202 when started; 409 when a run (scheduled or manual) is already in progress.
+ */
+exports.runPnv = async (req, res) => {
+    try {
+        const result = await pnvScheduler.runManualRefresh();
+        if (!result.started) {
+            return res.status(409).json({ success: false, error: 'A catalogue refresh is already running.', reason: result.reason });
+        }
+        res.status(202).json({ success: true, message: 'Catalogue refresh started.', startedAt: result.startedAt });
+    } catch (error) {
+        console.error('[admin/system] runPnv error:', error);
+        res.status(500).json({ success: false, error: error.message });
+    }
+};
+
+/**
+ * POST /api/admin/system/sync/own-sources/:feedId/run
+ * Triggers one Own Source feed import on demand (reuses the same path the scheduler/webhook use).
+ */
+exports.runOwnSource = (req, res) => {
+    const { feedId } = req.params;
+    if (!feedId) {
+        return res.status(400).json({ success: false, error: 'feedId is required.' });
+    }
+    if (externalImport.isBusy(feedId)) {
+        return res.status(409).json({ success: false, error: 'An import is already running for this feed.' });
+    }
+    externalImport.startImport(feedId, { trigger: 'manual' }).catch((err) => {
+        console.error(`[admin/system] own-source import for ${feedId} failed:`, err.message);
+    });
+    res.status(202).json({ success: true, message: `Import started for feed ${feedId}.`, startedAt: new Date().toISOString() });
+};

--- a/src/controllers/customExportController.js
+++ b/src/controllers/customExportController.js
@@ -1,4 +1,22 @@
 const customExportService = require('../services/customExport.service');
+const { recordActivity } = require('../services/activity.service');
+
+/**
+ * Records an export-download event against the partner who triggered it.
+ * JWT callers carry their own sub; api-key callers are attributed to the
+ * export owner (set on req.authContext.ownerSub by dualAuth).
+ */
+function logExportDownload(req, format) {
+    const ownerSub = req.authContext?.ownerSub || req.authContext?.sub || req.auth?.payload?.sub;
+    const email = req.authContext?.email || req.auth?.payload?.email;
+    recordActivity('export_download', {
+        ownerSub,
+        email,
+        resourceType: 'export_config',
+        resourceId: req.params.id,
+        metadata: { format }
+    });
+}
 
 /**
  * Error code to HTTP status mapping
@@ -136,6 +154,7 @@ exports.generateCsv = async (req, res) => {
 
         // Add BOM for Excel UTF-8 compatibility
         res.send('\ufeff' + csv);
+        logExportDownload(req, 'csv');
     } catch (error) {
         handleError(res, error);
     }
@@ -148,6 +167,7 @@ exports.generateJson = async (req, res) => {
     try {
         const data = await customExportService.generateJsonExport(req.params.id);
         res.json(data);
+        logExportDownload(req, 'json');
     } catch (error) {
         handleError(res, error);
     }
@@ -164,6 +184,7 @@ exports.generateXml = async (req, res) => {
             res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
         }
         res.send(xml);
+        logExportDownload(req, 'xml');
     } catch (error) {
         handleError(res, error);
     }

--- a/src/controllers/externalController.js
+++ b/src/controllers/externalController.js
@@ -2,6 +2,7 @@ const ownSource = require('../services/external/ownSource.service');
 const externalProducts = require('../services/external/externalProducts.service');
 const externalImport = require('../services/external/externalImport.service');
 const connectionService = require('../services/shopify/shopifyConnection.service');
+const { recordActivity } = require('../services/activity.service');
 
 /**
  * Controller for the "Own Sources" feed registry (design §8.1). Routes are JWT + export-role
@@ -62,6 +63,11 @@ exports.create = async (req, res) => {
         const created = await ownSource.createSource({
             ownerSub: sub, ownerEmail: email, brand: brand.trim(), url: url.trim(),
             authHeaderName, authToken, schedule, options
+        });
+        recordActivity('feed_add', {
+            ownerSub: sub, email,
+            resourceType: 'own_source', resourceId: created?.feedId,
+            metadata: { brand: created?.brand }
         });
         res.status(201).json({ success: true, source: created });
     } catch (error) {
@@ -124,6 +130,12 @@ exports.test = async (req, res) => {
             feed = { url, authHeaderName, authToken };
         }
         const result = await externalImport.testFeed(feed, { maxStalenessHours });
+        const { sub, email } = authUser(req);
+        recordActivity('feed_test', {
+            ownerSub: sub, email,
+            resourceType: 'own_source', resourceId: req.params.feedId || null,
+            metadata: { result: result?.lastResult || (result?.ok ? 'ok' : undefined) }
+        });
         res.json({ success: true, ...result });
     } catch (error) {
         handleError(res, error);
@@ -141,6 +153,11 @@ exports.importNow = async (req, res) => {
         // Fire-and-forget; the run records its own outcome on the feed's health + run history.
         externalImport.startImport(feedId, { trigger: 'manual' }).catch((err) => {
             console.error(`[external] import for ${feedId} failed:`, err.message);
+        });
+        const { sub, email } = authUser(req);
+        recordActivity('feed_import', {
+            ownerSub: sub, email,
+            resourceType: 'own_source', resourceId: feedId
         });
         res.status(202).json({ success: true, message: 'Import started' });
     } catch (error) {

--- a/src/controllers/shopifyController.js
+++ b/src/controllers/shopifyController.js
@@ -7,7 +7,7 @@ const syncService = require('../services/shopify/shopifySync.service');
 const syncJobs = require('../services/shopify/shopifySyncJobs.service');
 const productMap = require('../services/shopify/shopifyProductMap.service');
 const { getDistinctPricelists } = require('../services/customExport.service');
-const { verifyOAuthHmac, verifyWebhookHmac, hashClaimToken } = require('../services/shopify/crypto.service');
+const { verifyOAuthHmac, verifyWebhookHmac, verifyWebhookHmacWithSecret, decryptToken, hashClaimToken } = require('../services/shopify/crypto.service');
 const { recordActivity } = require('../services/activity.service');
 
 /**
@@ -139,6 +139,19 @@ function welcomeUrl(returnUrl) {
 }
 
 /**
+ * Where the browser is sent back after a CUSTOM_OAUTH (Prerelease) install completes. Explicit
+ * `SHOPIFY_PORTAL_PRERELEASE_RETURN_URL` wins; otherwise it's the normal return URL with the path
+ * swapped to the prerelease page, so a store connected from Prerelease lands back on Prerelease.
+ */
+function prereleaseReturnUrl() {
+    if (process.env.SHOPIFY_PORTAL_PRERELEASE_RETURN_URL) return process.env.SHOPIFY_PORTAL_PRERELEASE_RETURN_URL;
+    const base = process.env.SHOPIFY_PORTAL_RETURN_URL || '/';
+    return base.includes('/integrations/shopify')
+        ? base.replace('/integrations/shopify', '/integrations/shopify-prerelease')
+        : base;
+}
+
+/**
  * GET /shopify/connect?shop= — start OAuth. Returns the Shopify authorize URL for the
  * browser to redirect to (the UI does `window.location = url`).
  */
@@ -147,6 +160,139 @@ exports.connect = async (req, res) => {
         const { sub, email } = authUser(req);
         const { url, shop } = oauthService.buildInstallUrl({ shopInput: req.query.shop, sub, email });
         res.json({ success: true, url, shop });
+    } catch (error) {
+        handleError(res, error);
+    }
+};
+
+/**
+ * POST /shopify/connect-custom — "Shopify Prerelease" / Route B: bind a store using a
+ * merchant-supplied **custom-app** Admin API access token instead of OAuth. This lets pilot
+ * customers use the integration before the public app clears Shopify review — each creates a
+ * custom app in their own store admin, enables the Admin API scopes, and pastes the token here.
+ *
+ * Body: `{ shop, accessToken }`. We validate the token by fetching shop info (so a bad token or
+ * wrong store is rejected before anything is stored), then upsert an active, owner-bound
+ * connection with `authMethod: 'custom_app'`. Everything downstream (config, sync, activity,
+ * disconnect) is shared with the OAuth flow.
+ */
+exports.connectCustom = async (req, res) => {
+    try {
+        const { sub, email } = authUser(req);
+        const shop = oauthService.normalizeShopDomain(req.body?.shop);
+        const accessToken = String(req.body?.accessToken || '').trim();
+        if (!shop) {
+            const error = new Error('Enter a valid store domain (your-store.myshopify.com).');
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+        if (!accessToken) {
+            const error = new Error('Paste the Admin API access token from your custom app.');
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+
+        // Validate the token against the store BEFORE persisting anything. getShopInfo also returns
+        // the store's own myshopifyDomain, so we can catch a token pasted for the wrong store.
+        let shopInfo;
+        try {
+            shopInfo = await shopifyGraphql.getShopInfo(shop, accessToken);
+        } catch (err) {
+            const error = new Error(
+                err.code === 'SHOPIFY_AUTH'
+                    ? 'That token was rejected by the store. Check you pasted the Admin API access token (it starts with "shpat_") and that the custom app is installed with the required scopes.'
+                    : `Couldn't reach ${shop}. Check the store domain is correct and try again.`
+            );
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+        if (shopInfo?.domain && shopInfo.domain !== shop) {
+            const error = new Error(`That token belongs to ${shopInfo.domain}, not ${shop}. Enter the matching store domain.`);
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+
+        const connection = await connectionService.upsertCustomAppConnection({
+            ownerSub: sub,
+            ownerEmail: email,
+            shopDomain: shop,
+            accessToken,
+            shopInfo
+        });
+        recordActivity('shopify_connect', {
+            ownerSub: sub, email,
+            resourceType: 'shopify_connection', resourceId: connection?._id,
+            metadata: { shopDomain: shop, method: 'custom_app' }
+        });
+        res.json({ success: true, connection });
+    } catch (error) {
+        handleError(res, error);
+    }
+};
+
+/**
+ * POST /shopify/connect-custom-oauth — "Shopify Prerelease" via the customer's OWN OAuth app
+ * (bring-your-own-app). Body: `{ shop, clientId, clientSecret }`. Parks the app credentials in a
+ * one-time registration, then returns the Shopify authorize URL (built with the customer's
+ * client_id) for the browser to redirect to. The real install completes at `/callback-custom`.
+ */
+exports.connectCustomOAuth = async (req, res) => {
+    try {
+        const { sub, email } = authUser(req);
+        const shop = oauthService.normalizeShopDomain(req.body?.shop);
+        const clientId = String(req.body?.clientId || '').trim();
+        const clientSecret = String(req.body?.clientSecret || '').trim();
+        if (!shop) {
+            const error = new Error('Enter a valid store domain (your-store.myshopify.com).');
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+        if (!clientId || !clientSecret) {
+            const error = new Error("Paste your app's API key (client ID) and API secret key.");
+            error.code = 'VALIDATION_ERROR';
+            throw error;
+        }
+        const registration = await connectionService.createAppRegistration({
+            ownerSub: sub, ownerEmail: email, shopDomain: shop, appClientId: clientId, appClientSecret: clientSecret
+        });
+        const { url } = oauthService.buildCustomInstallUrl({
+            shopInput: shop, sub, email, clientId, registrationId: registration._id.toString()
+        });
+        res.json({ success: true, url, shop });
+    } catch (error) {
+        handleError(res, error);
+    }
+};
+
+/**
+ * GET /shopify/connection/:id/reconnect-custom — re-run OAuth for a bring-your-own-app
+ * (custom_oauth) store using its ALREADY-STORED app credentials (no re-paste). Owner-checked.
+ * Returns the store's authorize URL. Used when the token can no longer be refreshed.
+ */
+exports.reconnectCustomOAuth = async (req, res) => {
+    try {
+        const connection = await loadOwned(req);
+        if (connection.authMethod !== 'custom_oauth') {
+            const error = new Error('This store was not connected with your own app.');
+            error.code = 'BAD_REQUEST';
+            throw error;
+        }
+        const raw = await connectionService.getConnectionWithToken(connection._id);
+        if (!raw?.appClientId || !raw?.appClientSecretEnc) {
+            const error = new Error('This connection is missing its app credentials — reconnect from the connect screen.');
+            error.code = 'BAD_REQUEST';
+            throw error;
+        }
+        const { sub, email } = authUser(req);
+        const clientId = raw.appClientId;
+        const clientSecret = decryptToken(raw.appClientSecretEnc);
+        const registration = await connectionService.createAppRegistration({
+            ownerSub: sub, ownerEmail: email, shopDomain: connection.shopDomain, appClientId: clientId, appClientSecret: clientSecret
+        });
+        const { url } = oauthService.buildCustomInstallUrl({
+            shopInput: connection.shopDomain, sub, email, clientId, registrationId: registration._id.toString()
+        });
+        res.json({ success: true, url });
     } catch (error) {
         handleError(res, error);
     }
@@ -217,6 +363,28 @@ exports.callback = async (req, res) => {
         console.error('[shopify] callback failed:', error.code || '', error.message);
         const sep = returnUrl.includes('?') ? '&' : '?';
         res.redirect(`${returnUrl}${sep}shopify=error&reason=${encodeURIComponent(error.code || 'SERVER_ERROR')}`);
+    }
+};
+
+/**
+ * GET /shopify/callback-custom — OAuth redirect target for a CUSTOM_OAUTH (Prerelease) install.
+ * Verifies + persists using the customer's own app credentials, then 302s the browser back to the
+ * Prerelease page. On error, redirects with `?shopify=error` rather than a raw 500.
+ */
+exports.callbackCustom = async (req, res) => {
+    const returnUrl = prereleaseReturnUrl();
+    const sep = returnUrl.includes('?') ? '&' : '?';
+    try {
+        const { connection, webhooks } = await oauthService.handleCustomCallback(req.query);
+        let target = `${returnUrl}${sep}shopify=connected&shop=${encodeURIComponent(connection.shopDomain)}`;
+        if (webhooks.failed.length) target += '&webhooks=partial';
+        res.redirect(target);
+    } catch (error) {
+        console.error('[shopify] custom callback failed:', error.code || '', error.reason || '', error.message);
+        // Surface the specific reason (e.g. state_expired, state_shop_mismatch) so the browser banner
+        // and the API log both say exactly what failed.
+        const reason = error.reason || error.code || 'SERVER_ERROR';
+        res.redirect(`${returnUrl}${sep}shopify=error&reason=${encodeURIComponent(reason)}`);
     }
 };
 
@@ -526,12 +694,16 @@ exports.disconnect = async (req, res) => {
         // Best-effort self-uninstall so the app is removed in Shopify too, not just in the portal.
         // If the token can't be obtained/used (already uninstalled, refresh dead), we still drop
         // our record — the merchant's app card may linger but it has no working access either way.
-        try {
-            const token = await tokenService.getValidAccessToken(connection._id);
-            await shopifyApi.uninstallApp(connection.shopDomain, token);
-        } catch (err) {
-            console.warn('[shopify] self-uninstall on disconnect failed (continuing):',
-                err.code || err.response?.status || err.message);
+        // Skipped for custom-app (Prerelease) connections: there is no OAuth app to uninstall — the
+        // merchant owns that custom app in their own admin — so we just drop our record and token.
+        if (connection.authMethod !== 'custom_app') {
+            try {
+                const token = await tokenService.getValidAccessToken(connection._id);
+                await shopifyApi.uninstallApp(connection.shopDomain, token);
+            } catch (err) {
+                console.warn('[shopify] self-uninstall on disconnect failed (continuing):',
+                    err.code || err.response?.status || err.message);
+            }
         }
         await connectionService.deleteConnection(req.params.id);
         // Drop the now-orphaned product map (so a later reinstall re-matches cleanly) and the
@@ -549,12 +721,37 @@ exports.disconnect = async (req, res) => {
  * `X-Shopify-Topic` header. Always responds 200 quickly (Shopify retries on non-2xx); the
  * GDPR topics are acknowledged even though this is a one-way push app holding no customer data.
  */
+/**
+ * Fallback webhook verification for custom_oauth (bring-your-own-app) connections: a webhook from
+ * such an app is signed with THAT app's secret, not our shared one. Look up the shop's connections
+ * and try each stored app secret. Best-effort — any lookup/decrypt error just means "not verified".
+ */
+async function verifyWebhookForShop(rawBody, hmac, shopDomain) {
+    if (!shopDomain || !hmac) return false;
+    let conns;
+    try {
+        conns = await connectionService.findRawByShopDomain(shopDomain);
+    } catch {
+        return false;
+    }
+    for (const c of conns) {
+        if (c.authMethod === 'custom_oauth' && c.appClientSecretEnc) {
+            try {
+                if (verifyWebhookHmacWithSecret(rawBody, hmac, decryptToken(c.appClientSecretEnc))) return true;
+            } catch {
+                // try the next connection
+            }
+        }
+    }
+    return false;
+}
+
 exports.webhook = async (req, res) => {
     const hmac = req.get('X-Shopify-Hmac-Sha256');
     const topic = req.get('X-Shopify-Topic');
     const shopDomain = req.get('X-Shopify-Shop-Domain');
 
-    if (!verifyWebhookHmac(req.rawBody, hmac)) {
+    if (!verifyWebhookHmac(req.rawBody, hmac) && !(await verifyWebhookForShop(req.rawBody, hmac, shopDomain))) {
         return res.status(401).json({ message: 'Invalid webhook HMAC' });
     }
 

--- a/src/controllers/shopifyController.js
+++ b/src/controllers/shopifyController.js
@@ -8,6 +8,7 @@ const syncJobs = require('../services/shopify/shopifySyncJobs.service');
 const productMap = require('../services/shopify/shopifyProductMap.service');
 const { getDistinctPricelists } = require('../services/customExport.service');
 const { verifyOAuthHmac, verifyWebhookHmac, hashClaimToken } = require('../services/shopify/crypto.service');
+const { recordActivity } = require('../services/activity.service');
 
 /**
  * Controller for the Shopify connection lifecycle (design §10).
@@ -240,6 +241,11 @@ exports.claim = async (req, res) => {
             ownerSub: sub,
             ownerEmail: email
         });
+        recordActivity('shopify_connect', {
+            ownerSub: sub, email,
+            resourceType: 'shopify_connection', resourceId: connection?._id,
+            metadata: { shopDomain: shop }
+        });
         res.json({ success: true, connection });
     } catch (error) {
         handleError(res, error);
@@ -438,6 +444,11 @@ exports.sync = async (req, res) => {
     try {
         const connection = await loadOwned(req);
         const job = await syncService.startStockSync(connection._id, { trigger: 'manual' });
+        recordActivity('shopify_sync_now', {
+            ownerSub: connection.ownerSub, email: connection.ownerEmail,
+            resourceType: 'shopify_connection', resourceId: connection._id,
+            metadata: { shopDomain: connection.shopDomain }
+        });
         res.status(202).json({ success: true, job: toActivityRow(job) });
     } catch (error) {
         handleError(res, error);

--- a/src/middleware/dualAuth.js
+++ b/src/middleware/dualAuth.js
@@ -1,5 +1,6 @@
 const jwtCheck = require('./auth0');
 const apiKeyService = require('../services/apiKey.service');
+const { touchLastActive } = require('../services/activity.service');
 
 /**
  * Dual-auth middleware: tries JWT first, falls back to API key.
@@ -19,6 +20,8 @@ async function dualAuth(req, res, next) {
                 sub: payload.sub,
                 email: payload.email
             };
+            // Fire-and-forget: record last-active + emit a login event on session start.
+            touchLastActive(payload.sub, payload.email);
             return next();
         });
     }
@@ -32,8 +35,15 @@ async function dualAuth(req, res, next) {
             req.authContext = {
                 type: 'apikey',
                 sub: `apikey:${result.keyId}`,
-                exportId: result.exportConfig._id.toString()
+                exportId: result.exportConfig._id.toString(),
+                // The Auth0 owner behind this key — used to attribute activity to a real partner.
+                ownerSub: result.exportConfig.owner?.sub || null,
+                email: result.exportConfig.owner?.email || null
             };
+            // Attribute api-key traffic to the export owner (a real partner), not the key id.
+            if (req.authContext.ownerSub) {
+                touchLastActive(req.authContext.ownerSub, req.authContext.email);
+            }
             return next();
         } catch (err) {
             return res.status(500).json({ message: 'Authentication error' });

--- a/src/middleware/internalAdminToken.js
+++ b/src/middleware/internalAdminToken.js
@@ -1,0 +1,26 @@
+/**
+ * Guards the internal admin surface (`/api/admin/partners/*`) with a shared
+ * bearer token. The t4a-admin app calls these endpoints server-side with
+ * `Authorization: Bearer <PARTNER_ADMIN_TOKEN>`; the token never reaches a
+ * browser. Mirrors webhookApiKey.js but for a bearer header.
+ */
+const internalAdminToken = (req, res, next) => {
+    const expected = process.env.PARTNER_ADMIN_TOKEN;
+
+    if (!expected) {
+        console.error('PARTNER_ADMIN_TOKEN is not set in environment variables.');
+        return res.status(500).json({ message: 'Admin token not configured on server.' });
+    }
+
+    const header = req.headers.authorization || '';
+    const provided = header.startsWith('Bearer ') ? header.slice(7) : null;
+
+    if (!provided || provided !== expected) {
+        return res.status(401).json({ message: 'Unauthorized: invalid or missing bearer token.' });
+    }
+
+    req.adminContext = { type: 'internal_admin' };
+    next();
+};
+
+module.exports = internalAdminToken;

--- a/src/routes/adminPartnersRoutes.js
+++ b/src/routes/adminPartnersRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/adminPartnersController');
+
+// NOTE: `/overview` MUST be declared before `/:sub` so it is not swallowed by the
+// param route. `:sub` is an Auth0 sub (e.g. "auth0|123"), URL-encoded by the caller.
+
+router.get('/overview', controller.overview);
+
+router.get('/:sub', controller.detail);
+router.get('/:sub/activity', controller.activity);
+
+router.get('/:sub/notes', controller.listNotes);
+router.post('/:sub/notes', controller.addNote);
+router.delete('/:sub/notes/:noteId', controller.deleteNote);
+
+module.exports = router;

--- a/src/routes/adminSystemRoutes.js
+++ b/src/routes/adminSystemRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/adminSystemController');
+
+// Internal admin surface for the t4a-admin "Catalogue Sync" page. Mounted behind
+// internalAdminToken (shared bearer) in app.js — see /api/admin/system.
+
+router.get('/sync', controller.syncStatus);
+router.post('/sync/pnv/run', controller.runPnv);
+router.post('/sync/own-sources/:feedId/run', controller.runOwnSource);
+
+module.exports = router;

--- a/src/routes/externalRoutes.js
+++ b/src/routes/externalRoutes.js
@@ -3,25 +3,22 @@ const router = express.Router();
 
 const jwtCheck = require('../middleware/auth0');
 const requireExportRole = require('../middleware/requireExportRole');
-const requireTier = require('../middleware/requireTier');
-// Shopify + Own Sources are in the ALPHA program (design: early-access tiers) — flip or drop here.
-const requireAlpha = requireTier('alpha');
 const externalController = require('../controllers/externalController');
 
-// All Own Sources routes are JWT + export-role gated; ownership is checked per-feed in the
-// controller (mirrors shopifyRoutes). Mounted at /api/export/external.
+// Own Sources is now generally available: routes are JWT + export-role gated (no early-access tier).
+// Ownership is checked per-feed in the controller (mirrors shopifyRoutes). Mounted at /api/export/external.
 
 // Transient pre-save test (no feedId): validate an arbitrary feed URL before persisting it.
-router.post('/test', jwtCheck, requireExportRole, requireAlpha, externalController.test);
+router.post('/test', jwtCheck, requireExportRole, externalController.test);
 
-router.get('/sources', jwtCheck, requireExportRole, requireAlpha, externalController.list);
-router.post('/sources', jwtCheck, requireExportRole, requireAlpha, externalController.create);
-router.get('/sources/:feedId', jwtCheck, requireExportRole, requireAlpha, externalController.get);
-router.put('/sources/:feedId', jwtCheck, requireExportRole, requireAlpha, externalController.update);
-router.delete('/sources/:feedId', jwtCheck, requireExportRole, requireAlpha, externalController.remove);
-router.post('/sources/:feedId/test', jwtCheck, requireExportRole, requireAlpha, externalController.test);
-router.post('/sources/:feedId/import', jwtCheck, requireExportRole, requireAlpha, externalController.importNow);
-router.get('/sources/:feedId/activity', jwtCheck, requireExportRole, requireAlpha, externalController.activity);
-router.get('/sources/:feedId/products', jwtCheck, requireExportRole, requireAlpha, externalController.products);
+router.get('/sources', jwtCheck, requireExportRole, externalController.list);
+router.post('/sources', jwtCheck, requireExportRole, externalController.create);
+router.get('/sources/:feedId', jwtCheck, requireExportRole, externalController.get);
+router.put('/sources/:feedId', jwtCheck, requireExportRole, externalController.update);
+router.delete('/sources/:feedId', jwtCheck, requireExportRole, externalController.remove);
+router.post('/sources/:feedId/test', jwtCheck, requireExportRole, externalController.test);
+router.post('/sources/:feedId/import', jwtCheck, requireExportRole, externalController.importNow);
+router.get('/sources/:feedId/activity', jwtCheck, requireExportRole, externalController.activity);
+router.get('/sources/:feedId/products', jwtCheck, requireExportRole, externalController.products);
 
 module.exports = router;

--- a/src/routes/shopifyRoutes.js
+++ b/src/routes/shopifyRoutes.js
@@ -16,9 +16,21 @@ router.get('/entry', shopifyController.entry);
 // `connect` is started by a logged-in portal user (JWT + export role).
 router.get('/connect', jwtCheck, requireExportRole, requireAlpha, shopifyController.connect);
 
+// `connect-custom` is the "Shopify Prerelease" (Route B) path — a logged-in portal user pastes a
+// custom-app Admin API token instead of running OAuth. Same gating as `connect`.
+router.post('/connect-custom', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectCustom);
+
+// `connect-custom-oauth` is the "Shopify Prerelease" bring-your-own-OAuth-app path — a logged-in
+// portal user pastes their app's client_id + client_secret; we return their app's authorize URL.
+router.post('/connect-custom-oauth', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectCustomOAuth);
+
 // `callback` is hit by the browser redirect from Shopify — NO JWT. It is secured by
 // the OAuth HMAC + the signed `state` nonce instead (see crypto.service).
 router.get('/callback', shopifyController.callback);
+
+// `callback-custom` is the redirect target for a bring-your-own-OAuth-app install — NO JWT.
+// Secured by the signed `state` (identifies the app) + that app's own HMAC (see shopifyOAuth).
+router.get('/callback-custom', shopifyController.callbackCustom);
 
 // ─── Post-install claim / decline (Shopify-initiated pending connections) ───────
 // `claim` binds a pending install to the signed-in approved partner (alpha-gated). `decline` is
@@ -32,6 +44,8 @@ router.get('/status', jwtCheck, requireExportRole, requireAlpha, shopifyControll
 router.get('/connections', jwtCheck, requireExportRole, requireAlpha, shopifyController.connections);
 router.get('/pricelists', jwtCheck, requireExportRole, requireAlpha, shopifyController.pricelists);
 router.get('/connection/:id/detail', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectionDetail);
+// Reconnect a bring-your-own-app (custom_oauth) store using its stored app credentials.
+router.get('/connection/:id/reconnect-custom', jwtCheck, requireExportRole, requireAlpha, shopifyController.reconnectCustomOAuth);
 router.put('/connection/:id/config', jwtCheck, requireExportRole, requireAlpha, shopifyController.updateConfig);
 router.post('/connection/:id/sync', jwtCheck, requireExportRole, requireAlpha, shopifyController.sync);
 router.post('/connection/:id/recreate', jwtCheck, requireExportRole, requireAlpha, shopifyController.recreate);

--- a/src/routes/shopifyRoutes.js
+++ b/src/routes/shopifyRoutes.js
@@ -4,8 +4,10 @@ const router = express.Router();
 const jwtCheck = require('../middleware/auth0');
 const requireExportRole = require('../middleware/requireExportRole');
 const requireTier = require('../middleware/requireTier');
-// Shopify + Own Sources are in the ALPHA program (design: early-access tiers) — flip or drop here.
-const requireAlpha = requireTier('alpha');
+// Shopify is now generally available — the shared public-app OAuth + all connection management are
+// gated only by the `export` role. The legacy "bring your own custom app" (Deprecated) connect
+// entry points stay behind the `beta` tier while that flow is wound down.
+const requireBeta = requireTier('beta');
 const shopifyController = require('../controllers/shopifyController');
 
 // ─── OAuth ────────────────────────────────────────────────────────────────────
@@ -14,15 +16,15 @@ const shopifyController = require('../controllers/shopifyController');
 router.get('/entry', shopifyController.entry);
 
 // `connect` is started by a logged-in portal user (JWT + export role).
-router.get('/connect', jwtCheck, requireExportRole, requireAlpha, shopifyController.connect);
+router.get('/connect', jwtCheck, requireExportRole, shopifyController.connect);
 
-// `connect-custom` is the "Shopify Prerelease" (Route B) path — a logged-in portal user pastes a
-// custom-app Admin API token instead of running OAuth. Same gating as `connect`.
-router.post('/connect-custom', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectCustom);
+// `connect-custom` is the "Shopify Deprecated" (Route B) path — a logged-in portal user pastes a
+// custom-app Admin API token instead of running OAuth. Kept on the beta tier while it's deprecated.
+router.post('/connect-custom', jwtCheck, requireExportRole, requireBeta, shopifyController.connectCustom);
 
-// `connect-custom-oauth` is the "Shopify Prerelease" bring-your-own-OAuth-app path — a logged-in
+// `connect-custom-oauth` is the "Shopify Deprecated" bring-your-own-OAuth-app path — a logged-in
 // portal user pastes their app's client_id + client_secret; we return their app's authorize URL.
-router.post('/connect-custom-oauth', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectCustomOAuth);
+router.post('/connect-custom-oauth', jwtCheck, requireExportRole, requireBeta, shopifyController.connectCustomOAuth);
 
 // `callback` is hit by the browser redirect from Shopify — NO JWT. It is secured by
 // the OAuth HMAC + the signed `state` nonce instead (see crypto.service).
@@ -33,24 +35,23 @@ router.get('/callback', shopifyController.callback);
 router.get('/callback-custom', shopifyController.callbackCustom);
 
 // ─── Post-install claim / decline (Shopify-initiated pending connections) ───────
-// `claim` binds a pending install to the signed-in approved partner (alpha-gated). `decline` is
-// the clean break for a non-approved install — NOT alpha-gated (a signed-in user without the tier
-// must be able to tidy up their own install); the one-time claim token authorizes both.
-router.post('/connection/claim', jwtCheck, requireExportRole, requireAlpha, shopifyController.claim);
+// `claim` binds a pending install to the signed-in partner. `decline` is the clean break for a
+// merchant who doesn't want to connect — both are authorized by the one-time claim token.
+router.post('/connection/claim', jwtCheck, requireExportRole, shopifyController.claim);
 router.post('/connection/decline', jwtCheck, requireExportRole, shopifyController.decline);
 
 // ─── Connection management (JWT + export role, owner-checked in controller) ─────
-router.get('/status', jwtCheck, requireExportRole, requireAlpha, shopifyController.status);
-router.get('/connections', jwtCheck, requireExportRole, requireAlpha, shopifyController.connections);
-router.get('/pricelists', jwtCheck, requireExportRole, requireAlpha, shopifyController.pricelists);
-router.get('/connection/:id/detail', jwtCheck, requireExportRole, requireAlpha, shopifyController.connectionDetail);
+router.get('/status', jwtCheck, requireExportRole, shopifyController.status);
+router.get('/connections', jwtCheck, requireExportRole, shopifyController.connections);
+router.get('/pricelists', jwtCheck, requireExportRole, shopifyController.pricelists);
+router.get('/connection/:id/detail', jwtCheck, requireExportRole, shopifyController.connectionDetail);
 // Reconnect a bring-your-own-app (custom_oauth) store using its stored app credentials.
-router.get('/connection/:id/reconnect-custom', jwtCheck, requireExportRole, requireAlpha, shopifyController.reconnectCustomOAuth);
-router.put('/connection/:id/config', jwtCheck, requireExportRole, requireAlpha, shopifyController.updateConfig);
-router.post('/connection/:id/sync', jwtCheck, requireExportRole, requireAlpha, shopifyController.sync);
-router.post('/connection/:id/recreate', jwtCheck, requireExportRole, requireAlpha, shopifyController.recreate);
-router.get('/connection/:id/activity', jwtCheck, requireExportRole, requireAlpha, shopifyController.activity);
-router.delete('/connection/:id', jwtCheck, requireExportRole, requireAlpha, shopifyController.disconnect);
+router.get('/connection/:id/reconnect-custom', jwtCheck, requireExportRole, shopifyController.reconnectCustomOAuth);
+router.put('/connection/:id/config', jwtCheck, requireExportRole, shopifyController.updateConfig);
+router.post('/connection/:id/sync', jwtCheck, requireExportRole, shopifyController.sync);
+router.post('/connection/:id/recreate', jwtCheck, requireExportRole, shopifyController.recreate);
+router.get('/connection/:id/activity', jwtCheck, requireExportRole, shopifyController.activity);
+router.delete('/connection/:id', jwtCheck, requireExportRole, shopifyController.disconnect);
 
 // ─── Webhooks ───────────────────────────────────────────────────────────────
 // HMAC-verified against the raw body (captured in app.js). No JWT — Shopify calls this.

--- a/src/services/activity.service.js
+++ b/src/services/activity.service.js
@@ -1,0 +1,114 @@
+const { getDb } = require('./db/mongo.service');
+
+/**
+ * Partner activity instrumentation.
+ *
+ * Writes a unified, append-only event stream (`activity_log`) plus a small
+ * per-partner rollup (`partner_activity`) that the admin Partners section reads
+ * back through the `/api/admin/partners/*` surface. Every write here is
+ * fire-and-forget — instrumentation must never break the request it observes,
+ * so failures are swallowed and logged (same posture as the legacy
+ * analytics.service.js stub).
+ */
+
+const ACTIVITY_COLLECTION = 'activity_log';
+const ROLLUP_COLLECTION = 'partner_activity';
+
+/** Allowed event types — keep in sync with the admin "most interacted with" UI. */
+const EVENT_TYPES = Object.freeze([
+    'login',
+    'export_download',
+    'shopify_connect',
+    'shopify_sync_now',
+    'feed_add',
+    'feed_test',
+    'feed_import',
+    'product_view',
+    'config_change'
+]);
+
+// A login row is only written when the partner has been idle longer than this,
+// so a busy session produces one "login" event rather than one per request.
+const LOGIN_GAP_MS = 30 * 60 * 1000;
+
+/**
+ * Append one activity event. Never throws into the caller.
+ * @param {string} eventType one of EVENT_TYPES
+ * @param {{ ownerSub:string, email?:string, resourceType?:string, resourceId?:string, metadata?:object }} ctx
+ */
+async function recordActivity(eventType, { ownerSub, email = null, resourceType = null, resourceId = null, metadata = {} } = {}) {
+    if (!ownerSub) return; // anonymous / api-key-without-owner traffic is not attributed
+    try {
+        await getDb().collection(ACTIVITY_COLLECTION).insertOne({
+            ownerSub,
+            email,
+            eventType,
+            resourceType,
+            resourceId: resourceId != null ? String(resourceId) : null,
+            metadata,
+            timestamp: new Date()
+        });
+    } catch (err) {
+        console.error('[activity] recordActivity failed:', err.message);
+    }
+}
+
+/**
+ * Bump a partner's last-active timestamp on every authenticated request, and
+ * emit a `login` event when they return after being idle (see LOGIN_GAP_MS).
+ * Fire-and-forget; never throws.
+ * @param {string} ownerSub Auth0 sub
+ * @param {string} [email]
+ */
+async function touchLastActive(ownerSub, email = null) {
+    if (!ownerSub) return;
+    try {
+        const db = getDb();
+        const now = new Date();
+        const prev = await db.collection(ROLLUP_COLLECTION).findOne(
+            { ownerSub },
+            { projection: { lastActiveAt: 1 } }
+        );
+        const isNewSession = !prev?.lastActiveAt || (now - new Date(prev.lastActiveAt)) > LOGIN_GAP_MS;
+
+        await db.collection(ROLLUP_COLLECTION).updateOne(
+            { ownerSub },
+            {
+                $set: { ownerSub, email, lastActiveAt: now },
+                ...(isNewSession ? { $inc: { loginCount: 1 } } : {})
+            },
+            { upsert: true }
+        );
+
+        if (isNewSession) {
+            await recordActivity('login', { ownerSub, email });
+        }
+    } catch (err) {
+        console.error('[activity] touchLastActive failed:', err.message);
+    }
+}
+
+/**
+ * Creates indexes for the activity collections. Called once at startup.
+ */
+async function ensureIndexes() {
+    try {
+        const db = getDb();
+        await db.collection(ACTIVITY_COLLECTION).createIndex({ ownerSub: 1, timestamp: -1 });
+        await db.collection(ACTIVITY_COLLECTION).createIndex({ ownerSub: 1, eventType: 1 });
+        await db.collection(ROLLUP_COLLECTION).createIndex({ ownerSub: 1 }, { unique: true });
+        await db.collection('partner_notes').createIndex({ ownerSub: 1, createdAt: -1 });
+        console.log('[activity] Activity indexes ensured.');
+    } catch (err) {
+        console.error('[activity] Index creation error:', err.message);
+    }
+}
+
+module.exports = {
+    ACTIVITY_COLLECTION,
+    ROLLUP_COLLECTION,
+    EVENT_TYPES,
+    recordActivity,
+    touchLastActive,
+    ensureIndexes
+};

--- a/src/services/customExport.service.js
+++ b/src/services/customExport.service.js
@@ -321,10 +321,13 @@ const createExportConfig = async (data, ownerContext = {}) => {
     const db = getDb();
     const collection = db.collection(COLLECTION_NAME);
 
-    // Check for duplicate name
+    // Check for a duplicate name — scoped to THIS owner. Names only need to be unique per account;
+    // two different partners may legitimately each have an export called "Shopify" (previously this
+    // check was global and rejected the second account's name).
     const existing = await collection.findOne({
         name: data.name.trim(),
-        isActive: true
+        isActive: true,
+        'owner.sub': ownerContext.sub || null
     });
 
     if (existing) {
@@ -475,12 +478,14 @@ const updateExportConfig = async (id, data) => {
         throw error;
     }
 
-    // Check for name conflict if name is being changed
+    // Check for name conflict if name is being changed — scoped to the SAME owner, so a rename only
+    // collides with the caller's own exports (not another account that happens to use that name).
     if (data.name && data.name !== existing.name) {
         const nameConflict = await collection.findOne({
             name: data.name.trim(),
             isActive: true,
-            _id: { $ne: new ObjectId(id) }
+            _id: { $ne: new ObjectId(id) },
+            'owner.sub': existing.owner?.sub ?? null
         });
         if (nameConflict) {
             const error = new Error('Export with this name already exists');

--- a/src/services/metakocka/warehouse.service.js
+++ b/src/services/metakocka/warehouse.service.js
@@ -2,11 +2,29 @@ const axios = require("axios");
 const { baseApiUrl, warehouse, secretKey, companyId } = require("../../config/metakocka/metakocka");
 
 /**
+ * Free (available-to-sell) amount for a single Metakocka stock row.
+ * Metakocka returns `free_amount` (= amount - reserved_amount) only when the company
+ * uses reservations; without reservations only `amount` is present, so we fall back to
+ * `amount - reserved_amount` (reserved defaults to 0, which reduces to `amount`).
+ * @param {{amount?: string|number, reserved_amount?: string|number, free_amount?: string|number}} row
+ * @returns {number}
+ */
+function rowFreeAmount(row) {
+    if (row.free_amount != null && row.free_amount !== '') return Number(row.free_amount);
+    return Number(row.amount || 0) - Number(row.reserved_amount || 0);
+}
+
+/**
  * Fetches all stock for a given warehouse from the Metakocka API.
  * It handles pagination by making multiple requests until all stock is retrieved.
  * The stock is returned as a Map for efficient O(1) lookups by product code.
+ *
+ * A product can have several stock rows within one warehouse (e.g. one per microlocation),
+ * so rows are SUMMED per product code rather than overwritten. The per-code entry carries
+ * the summed `free`, `amount` and `reserved` — `free` (available-to-sell) is what callers
+ * should use for catalogue stock; `amount`/`reserved` are kept for logging/diagnostics.
  * @param {string} [warehouseId=warehouse.t4aMainWarehouseId] - The ID of the warehouse to get stock for. Defaults to the main T4A warehouse.
- * @returns {Promise<Map<string, {code: string, amount: number, count_code: string, mk_id: string}>>} A promise that resolves to a Map of stock items, with product codes as keys.
+ * @returns {Promise<Map<string, {code: string, free: number, amount: number, reserved: number, count_code: string, mk_id: string}>>} A promise that resolves to a Map of stock items, with product codes as keys.
  */
 async function getWarehouseStock(warehouseId = warehouse.t4aMainWarehouseId) {
     const limit = 1000;
@@ -27,9 +45,26 @@ async function getWarehouseStock(warehouseId = warehouse.t4aMainWarehouseId) {
             break;
         }
 
-        // Add each stock item to the Map, keyed by product code for fast lookups.
-        for (const { code, amount, count_code, mk_id } of stockList) {
-            allStock.set(code, { code, amount, count_code, mk_id });
+        // Accumulate each stock row into the Map, keyed by product code. Multiple rows for the
+        // same code (e.g. different microlocations) are summed — overwriting would drop stock.
+        for (const row of stockList) {
+            const { code, count_code, mk_id } = row;
+            if (!code) continue;
+            const existing = allStock.get(code);
+            if (existing) {
+                existing.free += rowFreeAmount(row);
+                existing.amount += Number(row.amount || 0);
+                existing.reserved += Number(row.reserved_amount || 0);
+            } else {
+                allStock.set(code, {
+                    code,
+                    free: rowFreeAmount(row),
+                    amount: Number(row.amount || 0),
+                    reserved: Number(row.reserved_amount || 0),
+                    count_code,
+                    mk_id,
+                });
+            }
         }
         offset += limit;
     }
@@ -39,23 +74,25 @@ async function getWarehouseStock(warehouseId = warehouse.t4aMainWarehouseId) {
 
 /**
  * Finds the stock information for a specific product code within a given stock list.
- * @param {Map<string, {code: string, amount: number, count_code: string, mk_id: string}>} warehouseStock - The Map of stock items to search through.
+ * @param {Map<string, {code: string, free: number, amount: number, reserved: number, count_code: string, mk_id: string}>} warehouseStock - The Map of stock items to search through.
  * @param {string} code - The product code to find.
- * @returns {{code: string, amount: number, count_code: string, mk_id: string}|undefined} The stock item object if found, otherwise undefined.
+ * @returns {{code: string, free: number, amount: number, reserved: number, count_code: string, mk_id: string}|undefined} The stock item object if found, otherwise undefined.
  */
 function getProductStock(warehouseStock, code) {
     return warehouseStock.get(code);
 }
 
 /**
- * Finds the stock amount for a specific product code.
- * @param {Map<string, {code: string, amount: number, count_code: string, mk_id: string}>} warehouseStock - The Map of stock items to search through.
+ * Finds the FREE (available-to-sell) stock amount for a specific product code — i.e. physical
+ * stock minus reservations, summed across all warehouse rows. This is what the catalogue stores
+ * so reserved units are not advertised as available.
+ * @param {Map<string, {code: string, free: number, amount: number, reserved: number, count_code: string, mk_id: string}>} warehouseStock - The Map of stock items to search through.
  * @param {string} code - The product code to find.
- * @returns {number} The stock amount if the product is found, otherwise 0.
+ * @returns {number} The free stock amount if the product is found, otherwise 0.
  */
 function getProductStockAmount(warehouseStock, code) {
     const productStock = getProductStock(warehouseStock, code);
-    return productStock ? Number(productStock.amount) : 0;
+    return productStock ? Number(productStock.free) : 0;
 }
 
 module.exports = { getWarehouseStock, getProductStock, getProductStockAmount };

--- a/src/services/pnv/pnvScheduler.service.js
+++ b/src/services/pnv/pnvScheduler.service.js
@@ -28,6 +28,9 @@ const { syncAllConnections } = require('../shopify/shopifySync.service');
 
 const STATE_COLLECTION = 'scheduler_state';
 const STATE_ID = 'pnv-products-sync';
+// Per-run history (mirrors external_import_runs / shopify_sync_jobs). The scheduler_state doc only
+// holds the LATEST run; this collection keeps the trail the admin "Catalogue Sync" page shows.
+const RUNS_COLLECTION = 'pnv_sync_runs';
 
 const TICK_MS = 30 * 1000;
 // PNV download + Metakocka enrichment + AI categorization can legitimately take a while —
@@ -244,15 +247,142 @@ async function tick() {
         try {
             const stats = await runScheduledRefresh();
             await finishSlot(schedule, { result: 'ok', stats, startedAt });
+            await recordRun({ trigger: 'schedule', startedAt, result: 'ok', stats });
             console.log('[pnv-scheduler] catalogue refresh finished.');
         } catch (err) {
             console.error('[pnv-scheduler] catalogue refresh failed:', err.message);
             await finishSlot(schedule, { result: 'error', error: err.message, startedAt });
+            await recordRun({ trigger: 'schedule', startedAt, result: 'error', error: err.message });
         }
     } catch (err) {
         console.error('[pnv-scheduler] tick error:', err.message);
     } finally {
         ticking = false;
+    }
+}
+
+/** Appends a run record to the history collection. Best-effort — never blocks/fails a run. */
+async function recordRun({ trigger, startedAt, result, error = null, stats = null, finishedAt = new Date() }) {
+    try {
+        await getDb().collection(RUNS_COLLECTION).insertOne({
+            trigger,
+            result,
+            error,
+            stats: stats || null,
+            startedAt: startedAt || null,
+            finishedAt,
+            durationMs: startedAt ? finishedAt - startedAt : null,
+            createdAt: new Date()
+        });
+    } catch (e) {
+        console.error('[pnv-scheduler] recordRun failed:', e.message);
+    }
+}
+
+/** Most recent runs, newest-first (for the admin Catalogue Sync page). */
+async function listRuns(limit = 20) {
+    return getDb().collection(RUNS_COLLECTION)
+        .find({}).sort({ startedAt: -1 }).limit(limit).toArray();
+}
+
+/**
+ * Unified status block for the admin surface: the persisted scheduler_state plus a computed
+ * `isRunning` (a held, unexpired lock) and the recent run history.
+ */
+async function getStatus() {
+    const now = Date.now();
+    const schedule = configuredSchedule();
+    const st = await getDb().collection(STATE_COLLECTION).findOne({ _id: STATE_ID });
+    const isRunning = !!(st?.runningBy && st?.lockedUntil && new Date(st.lockedUntil).getTime() > now);
+    const runs = await listRuns(20);
+    return {
+        enabled: !!schedule,
+        schedule: schedule || st?.schedule || null,
+        isRunning,
+        runningBy: isRunning ? st.runningBy : null,
+        nextRunAt: st?.nextRunAt || null,
+        lastStartedAt: st?.lastStartedAt || null,
+        lastFinishedAt: st?.lastFinishedAt || null,
+        lastDurationMs: st?.lastDurationMs ?? null,
+        lastResult: st?.lastResult || null,
+        lastError: st?.lastError || null,
+        lastStats: st?.lastStats || null,
+        runs
+    };
+}
+
+/**
+ * Atomically claims the shared run-lock for a MANUAL run. Shares the same lock the cron uses, so a
+ * manual run and a scheduled run can never overlap. Returns the claimed doc, or null when a run
+ * (scheduled or manual) is already in progress. Ensures the state doc exists first — a manual run
+ * must work even when the scheduler is disabled and has never created one.
+ */
+async function claimManualSlot(nowMs) {
+    const now = new Date(nowMs);
+    const col = getDb().collection(STATE_COLLECTION);
+    await col.updateOne(
+        { _id: STATE_ID },
+        { $setOnInsert: { schedule: null, nextRunAt: null, lockedUntil: null, runningBy: null } },
+        { upsert: true }
+    );
+    return col.findOneAndUpdate(
+        { _id: STATE_ID, $or: [{ lockedUntil: null }, { lockedUntil: { $lte: now } }] },
+        { $set: { lockedUntil: new Date(nowMs + LOCK_MS), runningBy: `manual_${INSTANCE_ID}`, lastStartedAt: now } },
+        { returnDocument: 'after' }
+    );
+}
+
+/** Records a manual run's outcome and frees the lock — WITHOUT advancing `nextRunAt` (a manual run must not disturb the cron cadence). */
+async function finishManual({ result, error = null, stats = null, startedAt }) {
+    const now = new Date();
+    await getDb().collection(STATE_COLLECTION).updateOne(
+        { _id: STATE_ID },
+        { $set: {
+            lockedUntil: null,
+            runningBy: null,
+            lastFinishedAt: now,
+            lastDurationMs: startedAt ? now - startedAt : null,
+            lastResult: result,
+            lastError: error,
+            lastStats: stats,
+            updatedAt: now
+        } }
+    );
+}
+
+/**
+ * "Run now" — runs the SAME full pipeline as the cron (PNV → AI → Shopify) on demand. Claims the
+ * shared lock (returns `{ started: false, reason: 'already_running' }` if a run is in flight), runs
+ * in the background, records history, and frees the lock without touching the schedule.
+ */
+async function runManualRefresh() {
+    const claimed = await claimManualSlot(Date.now());
+    if (!claimed) return { started: false, reason: 'already_running' };
+
+    const startedAt = new Date(claimed.lastStartedAt || Date.now());
+    console.log('[pnv-scheduler] manual catalogue refresh requested.');
+    (async () => {
+        try {
+            const stats = await runScheduledRefresh();
+            await finishManual({ result: 'ok', stats, startedAt });
+            await recordRun({ trigger: 'manual', startedAt, result: 'ok', stats });
+            console.log('[pnv-scheduler] manual catalogue refresh finished.');
+        } catch (err) {
+            console.error('[pnv-scheduler] manual catalogue refresh failed:', err.message);
+            await finishManual({ result: 'error', error: err.message, startedAt });
+            await recordRun({ trigger: 'manual', startedAt, result: 'error', error: err.message });
+        }
+    })();
+    return { started: true, startedAt: startedAt.toISOString() };
+}
+
+/** Index for the run-history collection. Called once at startup (works even when the cron is off). */
+async function ensureIndexes() {
+    try {
+        await getDb().collection(RUNS_COLLECTION).createIndex({ startedAt: -1 });
+        console.log('[pnv-scheduler] run-history index ensured.');
+    } catch (e) {
+        console.error('[pnv-scheduler] index creation error:', e.message);
     }
 }
 
@@ -286,4 +416,4 @@ function stop() {
     if (timer) { clearInterval(timer); timer = null; }
 }
 
-module.exports = { start, stop, tick, runScheduledRefresh, INSTANCE_ID };
+module.exports = { start, stop, tick, runScheduledRefresh, runManualRefresh, getStatus, listRuns, ensureIndexes, INSTANCE_ID };

--- a/src/services/shopify/crypto.service.js
+++ b/src/services/shopify/crypto.service.js
@@ -79,6 +79,10 @@ function signState(data) {
         nonce: crypto.randomBytes(16).toString('hex'),
         ts: Date.now()
     };
+    // Per-customer (custom_oauth) installs carry the flow kind + the app-registration id, so the
+    // callback can find which app's secret to verify/exchange with (see shopifyOAuth.handleCustomCallback).
+    if (data.kind) payload.kind = data.kind;
+    if (data.reg) payload.reg = data.reg;
     const body = base64url(JSON.stringify(payload));
     const sig = base64url(crypto.createHmac('sha256', getStateSecret()).update(body).digest());
     return `${body}.${sig}`;
@@ -102,15 +106,16 @@ function verifyState(state, maxAgeMs = 10 * 60 * 1000) {
 }
 
 /**
- * Verifies the HMAC on an OAuth callback query string.
+ * Verifies the HMAC on an OAuth callback query string against a GIVEN app secret.
  * Shopify signs all params except `hmac`/`signature`, sorted, joined `k=v&k=v`,
- * HMAC-SHA256 with the app secret, hex-encoded.
+ * HMAC-SHA256 with the app secret, hex-encoded. Used for per-customer (custom_oauth) apps
+ * whose callback is signed with THEIR secret, not our shared one.
  * @param {Object} query - parsed query params
+ * @param {string} secret - the app's client secret
  * @returns {boolean}
  */
-function verifyOAuthHmac(query) {
-    const secret = process.env.SHOPIFY_API_SECRET;
-    if (!secret) throw new Error('SHOPIFY_API_SECRET must be set.');
+function verifyOAuthHmacWithSecret(query, secret) {
+    if (!secret) return false;
     const { hmac, signature, ...rest } = query;
     if (!hmac) return false;
     const message = Object.keys(rest)
@@ -122,7 +127,32 @@ function verifyOAuthHmac(query) {
 }
 
 /**
- * Verifies a Shopify webhook HMAC (`X-Shopify-Hmac-Sha256`) against the raw body.
+ * Verifies the OAuth callback HMAC using the shared app secret (SHOPIFY_API_SECRET).
+ * @param {Object} query - parsed query params
+ * @returns {boolean}
+ */
+function verifyOAuthHmac(query) {
+    const secret = process.env.SHOPIFY_API_SECRET;
+    if (!secret) throw new Error('SHOPIFY_API_SECRET must be set.');
+    return verifyOAuthHmacWithSecret(query, secret);
+}
+
+/**
+ * Verifies a Shopify webhook HMAC (`X-Shopify-Hmac-Sha256`) against the raw body using a GIVEN
+ * app secret. Used for per-customer (custom_oauth) apps whose webhooks are signed with THEIR secret.
+ * @param {Buffer|string} rawBody - the exact bytes Shopify sent (NOT re-serialized JSON)
+ * @param {string} hmacHeader - base64 HMAC from the request header
+ * @param {string} secret - the app's client secret
+ * @returns {boolean}
+ */
+function verifyWebhookHmacWithSecret(rawBody, hmacHeader, secret) {
+    if (!secret || !rawBody || !hmacHeader) return false;
+    const digest = crypto.createHmac('sha256', secret).update(rawBody).digest('base64');
+    return timingSafeEqualStr(digest, String(hmacHeader));
+}
+
+/**
+ * Verifies a Shopify webhook HMAC against the raw body using the shared app secret.
  * @param {Buffer|string} rawBody - the exact bytes Shopify sent (NOT re-serialized JSON)
  * @param {string} hmacHeader - base64 HMAC from the request header
  * @returns {boolean}
@@ -130,9 +160,7 @@ function verifyOAuthHmac(query) {
 function verifyWebhookHmac(rawBody, hmacHeader) {
     const secret = process.env.SHOPIFY_API_SECRET;
     if (!secret) throw new Error('SHOPIFY_API_SECRET must be set.');
-    if (!rawBody || !hmacHeader) return false;
-    const digest = crypto.createHmac('sha256', secret).update(rawBody).digest('base64');
-    return timingSafeEqualStr(digest, String(hmacHeader));
+    return verifyWebhookHmacWithSecret(rawBody, hmacHeader, secret);
 }
 
 /**
@@ -172,7 +200,9 @@ module.exports = {
     signState,
     verifyState,
     verifyOAuthHmac,
+    verifyOAuthHmacWithSecret,
     verifyWebhookHmac,
+    verifyWebhookHmacWithSecret,
     makeClaimToken,
     hashClaimToken
 };

--- a/src/services/shopify/pendingCleanup.service.js
+++ b/src/services/shopify/pendingCleanup.service.js
@@ -1,6 +1,25 @@
 const connectionService = require('./shopifyConnection.service');
 const tokenService = require('./shopifyToken.service');
 const shopifyApi = require('./shopifyApi.service');
+const { getDb } = require('../db/mongo.service');
+
+// Last-sweep metadata lives in the shared scheduler_state collection so the admin "Catalogue Sync"
+// page can show when this best-effort sweep last ran (it keeps no other state).
+const STATE_COLLECTION = 'scheduler_state';
+const STATE_ID = 'shopify-pending-cleanup';
+
+/** Records the latest sweep outcome (best-effort — a failed write never affects the sweep). */
+async function recordSweep(removed) {
+    try {
+        await getDb().collection(STATE_COLLECTION).updateOne(
+            { _id: STATE_ID },
+            { $set: { lastSweepAt: new Date(), lastRemoved: removed, intervalMs: SWEEP_INTERVAL_MS, pendingTtlMs: PENDING_TTL_MS } },
+            { upsert: true }
+        );
+    } catch (err) {
+        console.error('[shopify-cleanup] recordSweep failed:', err.message);
+    }
+}
 
 /**
  * Periodic cleanup of abandoned PENDING Shopify connections.
@@ -31,7 +50,10 @@ async function runSweep() {
         console.error('[shopify-cleanup] could not list stale pending connections:', err.message);
         return { swept: 0 };
     }
-    if (!stale.length) return { swept: 0 };
+    if (!stale.length) {
+        await recordSweep(0);
+        return { swept: 0 };
+    }
 
     let swept = 0;
     for (const conn of stale) {
@@ -51,6 +73,7 @@ async function runSweep() {
         }
     }
     if (swept) console.log(`[shopify-cleanup] swept ${swept} abandoned pending connection(s).`);
+    await recordSweep(swept);
     return { swept };
 }
 
@@ -71,4 +94,4 @@ function stop() {
     if (timer) { clearInterval(timer); timer = null; }
 }
 
-module.exports = { start, stop, runSweep };
+module.exports = { start, stop, runSweep, STATE_ID, SWEEP_INTERVAL_MS, PENDING_TTL_MS };

--- a/src/services/shopify/shopifyApi.service.js
+++ b/src/services/shopify/shopifyApi.service.js
@@ -22,15 +22,17 @@ const API_VERSION = process.env.SHOPIFY_API_VERSION || '2026-04';
  *
  * @param {string} shop - full myshopify domain
  * @param {string} code - authorization code from the callback
+ * @param {{ clientId?: string, clientSecret?: string }} [creds] - per-app credentials for a
+ *   custom_oauth (bring-your-own) app; defaults to the shared app's env credentials.
  * @returns {Promise<{ access_token: string, scope: string, expires_in: number,
  *   refresh_token: string, refresh_token_expires_in: number }>}
  */
-async function exchangeCodeForToken(shop, code) {
+async function exchangeCodeForToken(shop, code, creds = {}) {
     const { data } = await axios.post(
         `https://${shop}/admin/oauth/access_token`,
         {
-            client_id: process.env.SHOPIFY_API_KEY,
-            client_secret: process.env.SHOPIFY_API_SECRET,
+            client_id: creds.clientId || process.env.SHOPIFY_API_KEY,
+            client_secret: creds.clientSecret || process.env.SHOPIFY_API_SECRET,
             code,
             expiring: '1'
         },
@@ -46,15 +48,17 @@ async function exchangeCodeForToken(shop, code) {
  *
  * @param {string} shop - full myshopify domain
  * @param {string} refreshToken
+ * @param {{ clientId?: string, clientSecret?: string }} [creds] - per-app credentials for a
+ *   custom_oauth (bring-your-own) app; defaults to the shared app's env credentials.
  * @returns {Promise<{ access_token: string, scope: string, expires_in: number,
  *   refresh_token: string, refresh_token_expires_in: number }>}
  */
-async function refreshAccessToken(shop, refreshToken) {
+async function refreshAccessToken(shop, refreshToken, creds = {}) {
     const { data } = await axios.post(
         `https://${shop}/admin/oauth/access_token`,
         {
-            client_id: process.env.SHOPIFY_API_KEY,
-            client_secret: process.env.SHOPIFY_API_SECRET,
+            client_id: creds.clientId || process.env.SHOPIFY_API_KEY,
+            client_secret: creds.clientSecret || process.env.SHOPIFY_API_SECRET,
             grant_type: 'refresh_token',
             refresh_token: refreshToken
         },

--- a/src/services/shopify/shopifyConnection.service.js
+++ b/src/services/shopify/shopifyConnection.service.js
@@ -530,6 +530,12 @@ async function updateConnectionConfig(id, patch) {
         }
     }
     if ('shopifyLocationId' in patch) set.shopifyLocationId = patch.shopifyLocationId;
+    // Optional friendly label a partner gives a store (shown in the switcher pill + panel header).
+    // Trimmed; an empty string clears it so the UI falls back to the raw *.myshopify.com domain.
+    if ('displayName' in patch) {
+        const name = typeof patch.displayName === 'string' ? patch.displayName.trim() : '';
+        set.displayName = name ? name.slice(0, 60) : null;
+    }
 
     const result = await collection.findOneAndUpdate(
         { _id: new ObjectId(id) },

--- a/src/services/shopify/shopifyConnection.service.js
+++ b/src/services/shopify/shopifyConnection.service.js
@@ -10,6 +10,10 @@ const { encryptToken } = require('./crypto.service');
  */
 
 const COLLECTION_NAME = 'shopify_connections';
+// Short-lived pre-OAuth registrations for the "bring your own OAuth app" (custom_oauth) flow: the
+// portal user's app credentials are parked here between "Connect" (build install URL) and the OAuth
+// callback, keyed by an id carried in the signed `state`. TTL-swept an hour after creation.
+const REGISTRATION_COLLECTION = 'shopify_app_registrations';
 
 const DEFAULT_SCOPES = (process.env.SHOPIFY_SCOPES ||
     'read_products,write_products,read_inventory,write_inventory,read_locations,read_publications,write_publications')
@@ -47,7 +51,9 @@ const DEFAULT_CONFIG = {
  */
 function toPublic(conn) {
     if (!conn) return null;
-    const { accessTokenEnc, refreshTokenEnc, ...rest } = conn;
+    // Strip every at-rest secret before a connection leaves the service: the encrypted access +
+    // refresh tokens AND a custom_oauth app's encrypted client secret.
+    const { accessTokenEnc, refreshTokenEnc, appClientSecretEnc, ...rest } = conn;
     return { ...rest, _id: conn._id.toString(), connected: conn.status === 'active' };
 }
 
@@ -79,6 +85,9 @@ async function upsertConnection({ ownerSub, ownerEmail, shopDomain, accessToken,
         refreshTokenEnc: refreshToken ? encryptToken(refreshToken) : null,
         tokenExpiresAt: expiryDate(expiresIn),
         refreshTokenExpiresAt: expiryDate(refreshTokenExpiresIn),
+        // Explicitly OAuth — so reconnecting a store here clears any prior 'custom_app' marker
+        // (Prerelease flow) and the token service resumes refreshing instead of returning as-is.
+        authMethod: 'oauth',
         scopes: scopes && scopes.length ? scopes : DEFAULT_SCOPES,
         shopName: shopInfo?.name || existing?.shopName || null,
         shopCurrency: shopInfo?.currency || existing?.shopCurrency || null,
@@ -101,6 +110,154 @@ async function upsertConnection({ ownerSub, ownerEmail, shopDomain, accessToken,
     };
     const result = await collection.insertOne(doc);
     return toPublic({ ...doc, _id: result.insertedId });
+}
+
+/**
+ * Upserts a connection authenticated by a merchant-supplied **custom-app** Admin API token
+ * (Route B / "Shopify Prerelease"). Unlike the OAuth path there is no `code` exchange and no
+ * refresh token — a custom app created in the store admin issues a single long-lived,
+ * non-expiring Admin API access token. `authMethod: 'custom_app'` marks the row so the token
+ * service returns the stored token as-is instead of trying to refresh it (which would fail).
+ * Keyed by (ownerSub, shopDomain) like {@link upsertConnection}, so re-pasting a token for the
+ * same store refreshes it in place and preserves the existing sync `config`.
+ * @returns {Promise<Object>} the public-shaped connection
+ */
+async function upsertCustomAppConnection({ ownerSub, ownerEmail, shopDomain, accessToken, scopes, shopInfo }) {
+    const db = getDb();
+    const collection = db.collection(COLLECTION_NAME);
+    const now = new Date();
+
+    const existing = await collection.findOne({ ownerSub, shopDomain });
+
+    const setFields = {
+        ownerSub,
+        ownerEmail: ownerEmail || null,
+        shopDomain,
+        accessTokenEnc: encryptToken(accessToken),
+        // Custom-app tokens don't expire and can't be refreshed — clear the OAuth-only fields so
+        // the token service takes the custom-app fast path (return-as-is) rather than the refresh path.
+        refreshTokenEnc: null,
+        tokenExpiresAt: null,
+        refreshTokenExpiresAt: null,
+        authMethod: 'custom_app',
+        // A custom app's granted scopes aren't introspectable from the token, so we record the
+        // scopes we ASK the merchant to enable (DEFAULT_SCOPES). A call needing a scope they didn't
+        // grant simply 403s at request time and is surfaced then (best-effort, as elsewhere).
+        scopes: scopes && scopes.length ? scopes : DEFAULT_SCOPES,
+        shopName: shopInfo?.name || existing?.shopName || null,
+        shopCurrency: shopInfo?.currency || existing?.shopCurrency || null,
+        status: 'active',
+        updatedAt: now
+    };
+
+    if (existing) {
+        await collection.updateOne({ _id: existing._id }, { $set: setFields });
+        return toPublic({ ...existing, ...setFields });
+    }
+
+    const doc = {
+        ...setFields,
+        shopifyLocationId: null,
+        config: { ...DEFAULT_CONFIG },
+        installedAt: now,
+        lastSyncAt: null,
+        lastSyncStatus: null
+    };
+    const result = await collection.insertOne(doc);
+    return toPublic({ ...doc, _id: result.insertedId });
+}
+
+/**
+ * Parks a portal user's own OAuth-app credentials before the OAuth redirect (custom_oauth /
+ * "bring your own app" flow). Returns the inserted doc (incl. `_id`); the id is embedded in the
+ * signed OAuth `state` so {@link getAppRegistration} can recover the client secret in the callback.
+ * The client secret is encrypted at rest with the same key as tokens.
+ * @returns {Promise<{ _id: ObjectId, ownerSub: string, ownerEmail: string|null, shopDomain: string, appClientId: string }>}
+ */
+async function createAppRegistration({ ownerSub, ownerEmail, shopDomain, appClientId, appClientSecret }) {
+    const db = getDb();
+    const doc = {
+        ownerSub,
+        ownerEmail: ownerEmail || null,
+        shopDomain,
+        appClientId,
+        appClientSecretEnc: encryptToken(appClientSecret),
+        createdAt: new Date()
+    };
+    const result = await db.collection(REGISTRATION_COLLECTION).insertOne(doc);
+    return { ...doc, _id: result.insertedId };
+}
+
+/** Returns a raw app-registration doc (INCLUDING the encrypted client secret) by id, or null. */
+async function getAppRegistration(id) {
+    if (!ObjectId.isValid(id)) return null;
+    return getDb().collection(REGISTRATION_COLLECTION).findOne({ _id: new ObjectId(id) });
+}
+
+/** Deletes an app registration once its OAuth callback has completed (or on abandonment). */
+async function deleteAppRegistration(id) {
+    if (!ObjectId.isValid(id)) return;
+    await getDb().collection(REGISTRATION_COLLECTION).deleteOne({ _id: new ObjectId(id) });
+}
+
+/**
+ * Upserts a connection installed via the customer's OWN OAuth app (custom_oauth / "bring your own
+ * app"). Identical token model to the shared-app {@link upsertConnection} (expiring offline token
+ * + refresh token), but ALSO stores the app's `appClientId` and encrypted `appClientSecretEnc` so
+ * the token service can refresh with the RIGHT app's credentials and the webhook handler can verify
+ * that app's HMAC. Keyed by (ownerSub, shopDomain); preserves an existing `config` on reconnect.
+ * @returns {Promise<Object>} the public-shaped connection
+ */
+async function upsertCustomOAuthConnection({ ownerSub, ownerEmail, shopDomain, accessToken, refreshToken, expiresIn, refreshTokenExpiresIn, scopes, shopInfo, appClientId, appClientSecret }) {
+    const db = getDb();
+    const collection = db.collection(COLLECTION_NAME);
+    const now = new Date();
+
+    const existing = await collection.findOne({ ownerSub, shopDomain });
+
+    const setFields = {
+        ownerSub,
+        ownerEmail: ownerEmail || null,
+        shopDomain,
+        accessTokenEnc: encryptToken(accessToken),
+        refreshTokenEnc: refreshToken ? encryptToken(refreshToken) : null,
+        tokenExpiresAt: expiryDate(expiresIn),
+        refreshTokenExpiresAt: expiryDate(refreshTokenExpiresIn),
+        authMethod: 'custom_oauth',
+        appClientId,
+        appClientSecretEnc: encryptToken(appClientSecret),
+        scopes: scopes && scopes.length ? scopes : DEFAULT_SCOPES,
+        shopName: shopInfo?.name || existing?.shopName || null,
+        shopCurrency: shopInfo?.currency || existing?.shopCurrency || null,
+        status: 'active',
+        updatedAt: now
+    };
+
+    if (existing) {
+        await collection.updateOne({ _id: existing._id }, { $set: setFields });
+        return toPublic({ ...existing, ...setFields });
+    }
+
+    const doc = {
+        ...setFields,
+        shopifyLocationId: null,
+        config: { ...DEFAULT_CONFIG },
+        installedAt: now,
+        lastSyncAt: null,
+        lastSyncStatus: null
+    };
+    const result = await collection.insertOne(doc);
+    return toPublic({ ...doc, _id: result.insertedId });
+}
+
+/**
+ * Returns ALL raw connection docs (INCLUDING encrypted secrets) for a shop domain. Used by the
+ * webhook handler to find a custom_oauth app's client secret so it can verify a webhook signed
+ * with that app's secret rather than the shared one. Never expose the result over the API.
+ * @returns {Promise<Array<Object>>}
+ */
+async function findRawByShopDomain(shopDomain) {
+    return getDb().collection(COLLECTION_NAME).find({ shopDomain }).toArray();
 }
 
 /**
@@ -172,6 +329,9 @@ async function claimPendingConnection({ shopDomain, claimTokenHash, ownerSub, ow
                 tokenExpiresAt: pending.tokenExpiresAt,
                 refreshTokenExpiresAt: pending.refreshTokenExpiresAt,
                 scopes: pending.scopes,
+                // A pending row always comes from OAuth — stamp it so claiming onto a store that was
+                // previously connected via the custom-app (Prerelease) flow clears that marker.
+                authMethod: 'oauth',
                 shopName: pending.shopName || existingOwned.shopName || null,
                 shopCurrency: pending.shopCurrency || existingOwned.shopCurrency || null,
                 ownerEmail: ownerEmail || existingOwned.ownerEmail || null,
@@ -509,6 +669,10 @@ async function ensureIndexes() {
         await db.collection(COLLECTION_NAME).createIndex({ shopDomain: 1 });
         await db.collection(COLLECTION_NAME).createIndex({ status: 1 });
 
+        // Pre-OAuth app registrations (custom_oauth flow) self-expire an hour after creation so an
+        // abandoned "Connect" never leaves an app's client secret parked indefinitely.
+        await db.collection(REGISTRATION_COLLECTION).createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 });
+
         // Forward-declared collections for the sync engine (design §6) — index now so the
         // data plane can be added later without a migration.
         await db.collection('shopify_product_map').createIndex({ connectionId: 1, sku: 1 });
@@ -528,6 +692,12 @@ module.exports = {
     DEFAULT_CONFIG,
     canPublish,
     upsertConnection,
+    upsertCustomAppConnection,
+    upsertCustomOAuthConnection,
+    createAppRegistration,
+    getAppRegistration,
+    deleteAppRegistration,
+    findRawByShopDomain,
     createPendingConnection,
     claimPendingConnection,
     getPendingByClaim,

--- a/src/services/shopify/shopifyOAuth.service.js
+++ b/src/services/shopify/shopifyOAuth.service.js
@@ -1,4 +1,4 @@
-const { signState, verifyState, verifyOAuthHmac, makeClaimToken, hashClaimToken } = require('./crypto.service');
+const { signState, verifyState, verifyOAuthHmac, verifyOAuthHmacWithSecret, decryptToken, makeClaimToken, hashClaimToken } = require('./crypto.service');
 const shopifyApi = require('./shopifyApi.service');
 const shopifyGraphql = require('./shopifyGraphql.service');
 const connectionService = require('./shopifyConnection.service');
@@ -178,8 +178,137 @@ async function handleCallback(query) {
     return { connection, webhooks };
 }
 
+/**
+ * Builds the Shopify OAuth authorize URL for a CUSTOM_OAUTH ("bring your own app") install. Unlike
+ * {@link buildInstallUrl} the `client_id` is the customer's OWN app id, the redirect goes to the
+ * dedicated `/shopify/callback-custom` route, and the signed state carries `kind:'custom_oauth'` +
+ * the app-registration id so the callback can recover the matching client secret.
+ * @param {{ shopInput: string, sub?: string, email?: string|null, clientId: string, registrationId: string }} args
+ * @returns {{ url: string, shop: string }}
+ */
+function buildCustomInstallUrl({ shopInput, sub, email, clientId, registrationId }) {
+    const shop = normalizeShopDomain(shopInput);
+    if (!shop) {
+        const error = new Error('Invalid shop domain');
+        error.code = 'VALIDATION_ERROR';
+        throw error;
+    }
+    if (!clientId) {
+        const error = new Error('App API key (client_id) is required.');
+        error.code = 'VALIDATION_ERROR';
+        throw error;
+    }
+    const state = signState({ sub: sub || null, email: email || null, shop, kind: 'custom_oauth', reg: registrationId });
+    const params = new URLSearchParams({
+        client_id: clientId,
+        scope: connectionService.DEFAULT_SCOPES.join(','),
+        redirect_uri: `${process.env.SHOPIFY_API_BASE_URL}/shopify/callback-custom`,
+        state
+    });
+    return { url: `https://${shop}/admin/oauth/authorize?${params.toString()}`, shop };
+}
+
+/**
+ * Handles the OAuth callback for a CUSTOM_OAUTH install. State is verified FIRST (it identifies the
+ * app registration → its client secret); only then can we verify Shopify's HMAC and exchange the
+ * code, both with the customer's OWN app credentials. On success the connection is persisted with
+ * `authMethod:'custom_oauth'` (+ the app's id/secret for later refresh & webhook verification) and
+ * the one-time registration is deleted.
+ * @param {Object} query - parsed callback query (`code`, `shop`, `state`, `hmac`, ...)
+ * @returns {Promise<{ connection: Object, webhooks: Object }>}
+ */
+async function handleCustomCallback(query) {
+    const { shop, code, state } = query;
+
+    // 1) State first — it's signed by US and tells us WHICH app (and its secret) this install is for.
+    // Allow up to 1h (matches the app-registration TTL) so time spent finishing the Dev Dashboard
+    // setup between "Connect" and approving doesn't expire the state.
+    let payload;
+    try {
+        payload = verifyState(state, 60 * 60 * 1000);
+    } catch (err) {
+        const error = new Error(`Invalid state: ${err.message}`);
+        error.code = 'INVALID_STATE';
+        // Distinguish an expired state from a bad signature / missing state, so the browser banner
+        // and logs pinpoint the cause instead of a generic INVALID_STATE.
+        error.reason = !state ? 'state_missing'
+            : /expired/i.test(err.message) ? 'state_expired'
+            : 'state_bad_signature';
+        throw error;
+    }
+    if (payload.kind !== 'custom_oauth' || !payload.reg) {
+        const error = new Error('State is not a custom-app install (wrong callback URL?)');
+        error.code = 'INVALID_STATE';
+        error.reason = 'state_not_custom';
+        throw error;
+    }
+
+    const normalized = normalizeShopDomain(shop);
+    if (!normalized || payload.shop !== normalized) {
+        const error = new Error(`State/shop mismatch (state=${payload.shop}, callback=${normalized})`);
+        error.code = 'INVALID_STATE';
+        error.reason = 'state_shop_mismatch';
+        throw error;
+    }
+
+    const reg = await connectionService.getAppRegistration(payload.reg);
+    if (!reg) {
+        const error = new Error('This connection attempt expired. Start again from the portal.');
+        error.code = 'NOT_FOUND';
+        throw error;
+    }
+    const clientId = reg.appClientId;
+    const clientSecret = decryptToken(reg.appClientSecretEnc);
+
+    // 2) Now verify Shopify's HMAC using THIS app's secret (proves Shopify sent it, untampered).
+    if (!verifyOAuthHmacWithSecret(query, clientSecret)) {
+        const error = new Error('HMAC validation failed');
+        error.code = 'INVALID_HMAC';
+        throw error;
+    }
+
+    // 3) Exchange the code with the customer's own app credentials.
+    const tokenResp = await shopifyApi.exchangeCodeForToken(normalized, code, { clientId, clientSecret });
+    const accessToken = tokenResp.access_token;
+    const grantedScopes = (tokenResp.scope || '').split(',').map((s) => s.trim()).filter(Boolean);
+
+    let shopInfo = null;
+    try {
+        shopInfo = await shopifyGraphql.getShopInfo(normalized, accessToken);
+    } catch (err) {
+        console.error('[shopify] getShopInfo failed after custom install:', err.message);
+    }
+
+    const connection = await connectionService.upsertCustomOAuthConnection({
+        ownerSub: reg.ownerSub,
+        ownerEmail: reg.ownerEmail,
+        shopDomain: normalized,
+        accessToken,
+        refreshToken: tokenResp.refresh_token,
+        expiresIn: tokenResp.expires_in,
+        refreshTokenExpiresIn: tokenResp.refresh_token_expires_in,
+        scopes: grantedScopes,
+        shopInfo,
+        appClientId: clientId,
+        appClientSecret: clientSecret
+    });
+
+    let webhooks = { registered: [], failed: [] };
+    try {
+        webhooks = await shopifyGraphql.registerWebhooks(normalized, accessToken);
+    } catch (err) {
+        console.error('[shopify] webhook registration failed (custom install):', err.message);
+    }
+
+    await connectionService.deleteAppRegistration(payload.reg);
+
+    return { connection, webhooks };
+}
+
 module.exports = {
     normalizeShopDomain,
     buildInstallUrl,
-    handleCallback
+    handleCallback,
+    buildCustomInstallUrl,
+    handleCustomCallback
 };

--- a/src/services/shopify/shopifyOAuth.service.js
+++ b/src/services/shopify/shopifyOAuth.service.js
@@ -100,10 +100,13 @@ async function handleCallback(query) {
         error.code = 'INVALID_STATE';
         throw error;
     }
+    // The callback's `shop` is the store's canonical *.myshopify.com domain, which can differ from
+    // what the user typed to START the flow — e.g. they entered a store alias or the (renamed)
+    // subdomain rather than the permanent one Shopify redirects back with. The HMAC above already
+    // proved Shopify sent THIS callback for `normalized`, so it's authoritative: log the divergence
+    // but proceed with the canonical domain instead of hard-failing with a confusing "invalid state".
     if (payload.shop !== normalized) {
-        const error = new Error('State/shop mismatch');
-        error.code = 'INVALID_STATE';
-        throw error;
+        console.warn(`[shopify] OAuth callback shop (${normalized}) differs from the requested domain (${payload.shop}); binding to the canonical callback domain.`);
     }
 
     // Shopify-initiated install: no portal user yet. Exchange the code and persist a PENDING
@@ -244,10 +247,9 @@ async function handleCustomCallback(query) {
     }
 
     const normalized = normalizeShopDomain(shop);
-    if (!normalized || payload.shop !== normalized) {
-        const error = new Error(`State/shop mismatch (state=${payload.shop}, callback=${normalized})`);
-        error.code = 'INVALID_STATE';
-        error.reason = 'state_shop_mismatch';
+    if (!normalized) {
+        const error = new Error('Invalid shop domain');
+        error.code = 'VALIDATION_ERROR';
         throw error;
     }
 
@@ -265,6 +267,13 @@ async function handleCustomCallback(query) {
         const error = new Error('HMAC validation failed');
         error.code = 'INVALID_HMAC';
         throw error;
+    }
+
+    // HMAC proved Shopify sent this callback for `normalized`. As in the shared-app flow, the
+    // canonical callback domain can differ from what the customer typed (an alias or renamed
+    // subdomain); trust the HMAC-verified domain and log rather than failing with an invalid-state.
+    if (payload.shop !== normalized) {
+        console.warn(`[shopify] Custom OAuth callback shop (${normalized}) differs from the requested domain (${payload.shop}); binding to the canonical callback domain.`);
     }
 
     // 3) Exchange the code with the customer's own app credentials.

--- a/src/services/shopify/shopifyToken.service.js
+++ b/src/services/shopify/shopifyToken.service.js
@@ -31,6 +31,13 @@ async function resolveToken(connectionId) {
     if (!conn) throw Object.assign(new Error('Connection not found'), { code: 'NOT_FOUND' });
     if (!conn.accessTokenEnc) throw Object.assign(new Error('Connection is not active'), { code: 'NOT_ACTIVE' });
 
+    // Custom-app (Prerelease / Route B) connections hold a merchant-supplied, non-expiring Admin
+    // API token — there is no refresh token and nothing to renew, so return it directly. (A dead
+    // custom token surfaces as a 401 at request time, handled by the caller like any revoked token.)
+    if (conn.authMethod === 'custom_app') {
+        return decryptToken(conn.accessTokenEnc);
+    }
+
     const expiresAt = conn.tokenExpiresAt ? new Date(conn.tokenExpiresAt).getTime() : null;
 
     // Legacy non-expiring token (pre-expiring-offline migration) — unrenewable and now
@@ -44,10 +51,14 @@ async function resolveToken(connectionId) {
         return decryptToken(conn.accessTokenEnc);
     }
 
-    // Near/past expiry — refresh, persist, and return the new access token.
+    // Near/past expiry — refresh, persist, and return the new access token. A custom_oauth
+    // (bring-your-own-app) connection must refresh with ITS OWN app credentials, not the shared ones.
+    const creds = conn.authMethod === 'custom_oauth' && conn.appClientId && conn.appClientSecretEnc
+        ? { clientId: conn.appClientId, clientSecret: decryptToken(conn.appClientSecretEnc) }
+        : undefined;
     let resp;
     try {
-        resp = await shopifyApi.refreshAccessToken(conn.shopDomain, decryptToken(conn.refreshTokenEnc));
+        resp = await shopifyApi.refreshAccessToken(conn.shopDomain, decryptToken(conn.refreshTokenEnc), creds);
     } catch (err) {
         // Refresh token expired/invalid → mark the connection and ask the user to reconnect.
         await connectionService.setStatus(conn._id, 'error');


### PR DESCRIPTION
@
## Summary
Merges the latest API work into `dev`.

- **Shopify + Own Sources → GA**: alpha tier gate removed (export-role only), per-account export/source name uniqueness, OAuth domain fix (canonical `.myshopify.com` binding), connection rename support.
- **Prerelease bring-your-own-app connect**: custom OAuth + token flow (`shopify_app_registrations`).
- **PNV scheduler**: uses free stock; scheduler status / run-now exposed to admin.
- **Admin partners API**: partner activity instrumentation + admin partners endpoints.

## Commits
- `c67bdda` Shopify/Own Sources GA; per-account export names; OAuth domain fix; connection rename
- `17d8af3` feat(shopify): prerelease bring-your-own-app connect (custom OAuth + token)
- `7c56410` Use free stock + expose scheduler status/run-now to admin
- `fe23f9b` feat(admin): partner activity instrumentation + admin partners API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@